### PR TITLE
ClassCastExceptions in Util.java

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -60,7 +60,7 @@ public final class Util {
         StringBuilder sb = new StringBuilder();
 
         for (String key : parameters.keySet()) {
-            if (parameters.getByteArray(key) != null) {
+            if (weHaveAByteArrayFor(parameters.get(key))) {
                 continue;
             }
 
@@ -152,7 +152,7 @@ public final class Util {
         if (!method.equals("GET")) {
             Bundle dataparams = new Bundle();
             for (String key : params.keySet()) {
-                if (params.getByteArray(key) != null) {
+                if (weHaveAByteArrayFor(params.get(key))) {
                         dataparams.putByteArray(key, params.getByteArray(key));
                 }
             }
@@ -298,4 +298,9 @@ public final class Util {
         alertBuilder.create().show();
     }
 
+    private static boolean weHaveAByteArrayFor(Object object) {
+      return byte[].class.isAssignableFrom(object.getClass());
+    }
+
+    
 }


### PR DESCRIPTION
There were two places (that I've found so far) that were generating ClassCastException traces for any bundle parameters that were not of type byte[]. This appears to be the majority of parameters.
I've changed the code to check the class type of the object stored in the bundle. This has removed the CCE's from the logs, while preserving the behaviour and intent of the original.
