### PR TITLE
onBackPressed() override added to FbDialog

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -111,6 +111,12 @@ public class FbDialog extends Dialog {
         mWebView.setLayoutParams(FILL);
         mContent.addView(mWebView);
     }
+    
+    @Override
+    public void onBackPressed() {
+    	mListener.onCancel();
+    	super.onBackPressed();
+    }
 
     private class FbWebViewClient extends WebViewClient {
 


### PR DESCRIPTION
Lets the application know when the FbDialog has been closed by the user pressing the Back button.
