### PR TITLE
Calls Cancel on DialogListener when Dialog is Cancelled

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -19,6 +19,7 @@ package com.facebook.android;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -87,6 +88,13 @@ public class FbDialog extends Dialog {
         addContentView(mContent, new LinearLayout.LayoutParams(
                 display.getWidth() - ((int) (dimensions[0] * scale + 0.5f)),
                 display.getHeight() - ((int) (dimensions[1] * scale + 0.5f))));
+        
+        this.setOnCancelListener(new OnCancelListener() {
+			@Override
+			public void onCancel(DialogInterface dialog) {
+				mListener.onCancel();
+			}
+		});
     }
 
     private void setUpTitle() {


### PR DESCRIPTION
Currently the back button does not cause the cancel method to fire on DialogListener. I can't find any other case why this would happen besides the back button, but I figure it's probably better to listen for the more general cancel.
