### PR TITLE
Look up Facebook icon by name, not resource ID

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -21,6 +21,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -50,7 +51,10 @@ public class FbDialog extends Dialog {
     static final int MARGIN = 4;
     static final int PADDING = 2;
     static final String DISPLAY_STRING = "touch";
-    static final String FB_ICON = "icon.png";
+    // Name of Facebook icon. You should copy this file from the Facebook SDK's resources
+    // to your project's "res/drawable" directory, along with the ldpi and hdpi versions
+    // to their respective directories.
+    static final String FB_ICON = "facebook_icon";
 
     private String mUrl;
     private DialogListener mListener;
@@ -89,10 +93,14 @@ public class FbDialog extends Dialog {
                 display.getHeight() - ((int) (dimensions[1] * scale + 0.5f))));
     }
 
+    private Drawable getIcon() {
+        Resources resources = getContext().getResources();
+        int iconResourceId = resources.getIdentifier(FB_ICON, "drawable", getContext().getPackageName());
+        return resources.getDrawable(iconResourceId);
+    }
+
     private void setUpTitle() {
         requestWindowFeature(Window.FEATURE_NO_TITLE);
-        Drawable icon = getContext().getResources().getDrawable(
-                R.drawable.facebook_icon);
         mTitle = new TextView(getContext());
         mTitle.setText("Facebook");
         mTitle.setTextColor(Color.WHITE);
@@ -101,7 +109,7 @@ public class FbDialog extends Dialog {
         mTitle.setPadding(MARGIN + PADDING, MARGIN, MARGIN, MARGIN);
         mTitle.setCompoundDrawablePadding(MARGIN + PADDING);
         mTitle.setCompoundDrawablesWithIntrinsicBounds(
-                icon, null, null, null);
+                getIcon(), null, null, null);
         mContent.addView(mTitle);
     }
 


### PR DESCRIPTION
Although it is preferred to use the resource ID when loading resources, this makes it such that the Facebook SDK won't build out of the box, as it lacks an import statement to the project's "R" class. This fix looks up the Facebook icon by name, meaning that in order to integrate the Facebook SDK, one only needs to copy the icons to their project's "drawable" directories.
