### PR TITLE
Fix ArrayOutOfBoundsException when clicking "Don't Allow" in FbDialog onc

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -93,8 +93,10 @@ public final class Util {
             String array[] = s.split("&");
             for (String parameter : array) {
                 String v[] = parameter.split("=");
-                params.putString(URLDecoder.decode(v[0]),
-                                 URLDecoder.decode(v[1]));
+                if (v.length > 1) {
+                    params.putString(URLDecoder.decode(v[0]),
+                                     URLDecoder.decode(v[1]));
+                }
             }
         }
         return params;


### PR DESCRIPTION
Fix ArrayOutOfBoundsException when clicking "Don't Allow" in FbDialog once logged in.

The Facebook SDK would cause a Force Close when a user clicked "Don't Allow" from the FbDialog once they logged in on the WebView.

The error stemmed from checking an array index without checking whether it was in range. The fix checks that the array is longer than 1 before using indexes 0 and 1.
