### PR TITLE
Pass dialog cancel events to the listener

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -19,6 +19,7 @@ package com.facebook.android;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -87,6 +88,11 @@ public class FbDialog extends Dialog {
         addContentView(mContent, new LinearLayout.LayoutParams(
                 display.getWidth() - ((int) (dimensions[0] * scale + 0.5f)),
                 display.getHeight() - ((int) (dimensions[1] * scale + 0.5f))));
+        setOnCancelListener(new OnCancelListener() {
+            public void onCancel(DialogInterface dialogInterface) {
+                mListener.onCancel();
+            }
+        });
     }
 
     private void setUpTitle() {


### PR DESCRIPTION
When not using single sign-on, it is important that the listener is able to receive cancel events from the dialog. Otherwise when the user presses "back" in the login screen, the listener will never know about it and therefore not be able to react to these changes.
