### PR TITLE
Fix exception when trying to decode invalid string

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -93,8 +93,10 @@ public final class Util {
             String array[] = s.split("&");
             for (String parameter : array) {
                 String v[] = parameter.split("=");
-                params.putString(URLDecoder.decode(v[0]),
-                                 URLDecoder.decode(v[1]));
+                if(v.length == 2) {
+                    params.putString(URLDecoder.decode(v[0]),
+                                     URLDecoder.decode(v[1]));
+                }
             }
         }
         return params;


### PR DESCRIPTION
This exception is barely seen in regular development, but if there is some problem with your corresponding Facebook App then Facebook will return URL fragments with a reference like "_", which caused this method to throw an uncaught ArrayIndexOutOfBoundsException. Since this method is splitting to key/values anyways, this little safety check will prevent the app from crashing.
