### PR TITLE
Adding some try/catch blocks for safety

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -164,7 +164,12 @@ public class FbDialog extends Dialog {
             super.onReceivedError(view, errorCode, description, failingUrl);
             mListener.onError(
                     new DialogError(description, errorCode, failingUrl));
-            FbDialog.this.dismiss();
+            try {
+                FbDialog.this.dismiss();
+            }
+            catch(Exception e) {
+                e.printStackTrace();
+            }
         }
 
         @Override


### PR DESCRIPTION
If the user hits the "back" button on their device at the right time (or rather, the wrong time), then this can cause the FBDialog class to throw some strange exceptions about not being attached to the current activity, etc. Better to just put in a bit of extra protection here and swallow any exceptions that may result.
