### PR TITLE
Adding a read timeout to http connection to fix no i/o exceptions on some situations

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -147,6 +147,8 @@ public final class Util {
         Log.d("Facebook-Util", method + " URL: " + url);
         HttpURLConnection conn =
             (HttpURLConnection) new URL(url).openConnection();
+        // We add a read timeout so, if connection falls during reading, we don't keep infinite-waiting
+        conn.setReadTimeout(10000);
         conn.setRequestProperty("User-Agent", System.getProperties().
                 getProperty("http.agent") + " FacebookAndroidSDK");
         if (!method.equals("GET")) {


### PR DESCRIPTION
If the connectivity falls while getting the input stream, connection keeps waiting to infinite by default. 
If the connectivity then restores in quite small time, the input stream retrieving goes on, but, if it stays down for some minutes, no input stream is retrieved and no io exception is thrown.
Setting a read timeout to the connection solves this issue.
