### PR TITLE
Android Source compatibility

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -97,7 +97,7 @@ public class FbDialog extends Dialog {
         mCrossImage = new ImageView(getContext());
         // Dismiss the dialog when user click on the 'x'
         mCrossImage.setOnClickListener(new View.OnClickListener() {
-            @Override
+            
             public void onClick(View v) {
                 mListener.onCancel();
                 FbDialog.this.dismiss();


### PR DESCRIPTION
Hi,
Android is Java 1.5 source compatible. Java 1.6 syntax is not supported. I pulled the new changes and saw that there was a stray Override around in the FBDialog class. This should just remove that and leave everything else alone :)

Thanks,
Greg 
