### PR TITLE
Fix for Issue #160: ClassCastExceptions filling up the logs.

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -60,7 +60,7 @@ public final class Util {
         StringBuilder sb = new StringBuilder();
 
         for (String key : parameters.keySet()) {
-            if (parameters.getByteArray(key) != null) {
+            if (!(parameters.get(key) instanceof String)) {
                 continue;
             }
 
@@ -152,8 +152,8 @@ public final class Util {
         if (!method.equals("GET")) {
             Bundle dataparams = new Bundle();
             for (String key : params.keySet()) {
-                if (params.getByteArray(key) != null) {
-                        dataparams.putByteArray(key, params.getByteArray(key));
+                if (params.get(key) instanceof String) {
+                        dataparams.putString(key, params.getString(key));
                 }
             }
 
@@ -187,7 +187,7 @@ public final class Util {
                 for (String key: dataparams.keySet()){
                     os.write(("Content-Disposition: form-data; filename=\"" + key + "\"" + endLine).getBytes());
                     os.write(("Content-Type: content/unknown" + endLine + endLine).getBytes());
-                    os.write(dataparams.getByteArray(key));
+                    os.write(dataparams.getString(key).getBytes());
                     os.write((endLine + "--" + strBoundary + endLine).getBytes());
 
                 }


### PR DESCRIPTION
This is a simple fix that takes care of annoying log spam. Would love it if a Facebook engineer could pull this. :-)

For each request made to facebook using this library, 5-10 instances of the following message is logged:
```10-27 13:28:04.342: WARN/Bundle(3671): Key format expected byte[] but value was a java.lang.String.  The default value <null> was returned.
10-27 13:28:04.346: WARN/Bundle(3671): Attempt to cast generated internal exception:
        java.lang.ClassCastException: java.lang.String
        at android.os.Bundle.getByteArray(Bundle.java:1305)
        at com.facebook.android.Util.encodePostBody(Util.java:52)
        at com.facebook.android.Util.openUrl(Util.java:173)
        at com.facebook.android.Facebook.request(Facebook.java:544)
        at com.facebook.android.AsyncFacebookRunner$2.run(AsyncFacebookRunner.java:239)

```

This is caused by calling Bundle.getByteArray() on a key that maps to a value which cannot be cast to a byte array, for example a String. For example, this code would cause the above log message:

```

Bundle bundle = new Bundle();
bundle.putString("format", "json");
bundle.getByteArray("format");

```

Since we never need to call setByteArray() on this Bundle, and since all of our parameters are just plain Strings, I have changed a few lines to use Bundle.getString() and Bundle.setString() exclusively, and then check that Bundle.get() returns a String where we expect one.

I have tested this against all the API requests my client uses. The API requests continue to work and the log message no longer appears.
```
