### PR TITLE
Show ok/cancel alert for unverified SSL certs

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -143,7 +143,7 @@ public class FbDialog extends Dialog {
             mListener.onCancel();
             dismiss();
           }
-        })
+        });
         builder.show();
       }
 


### PR DESCRIPTION
Unfortunately, HTC issued an update to the Wildfire S which contained
non-root CA's in the device's root keystore. The result is that HTTPS is
essentially broken, and users of these devices often get warnings from
the web browser when visiting secure sites.

Without this patch, the system will default to cancelling the load
operation, which leaves the resulting FbDialog with an empty page and no
error message. By popping up a dialog here, we give the user a chance to
continue or cancel at their own choice.
