### PR TITLE
Handle dismiss() properly in FbDialog

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -91,10 +91,12 @@ public class FbDialog extends Dialog {
 
   @Override
   public void cancel() {
-    super.cancel();
-    mListener.onCancel();
-    if(mWebView != null) {
-      mWebView.stopLoading();
+    if(isShowing()) {
+      super.cancel();
+      mListener.onCancel();
+      if(mWebView != null) {
+        mWebView.stopLoading();
+      }
     }
   }
 


### PR DESCRIPTION
This patch provides some better handling in the FbDialog class for when the user presses "back" to dismiss the popup dialog. The underlying WebView should cancel all pending requests, or else rogue progress dialogs can show up after pressing "back". Also, the dialog's listener should be informed about the cancel event.
