### PR TITLE
Use fullscreen theme for FBDialog if the context activity is fullscreen.

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -69,11 +69,11 @@ public class FbDialog extends Dialog {
     }
     
     private static boolean isFullScreenActivity(Context context) {
-      if (!(context instanceof Activity)) return false;
-      Window window = ((Activity) context).getWindow();
-      if (window == null) return false;
-      WindowManager.LayoutParams params = window.getAttributes();
-      return (params.flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0;
+        if (!(context instanceof Activity)) return false;
+        Window window = ((Activity) context).getWindow();
+        if (window == null) return false;
+        WindowManager.LayoutParams params = window.getAttributes();
+        return (params.flags & WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0;
     }
 
     @Override


### PR DESCRIPTION
This makes the user experience more seamless.
