### PR TITLE
Pass on SSL errors from WebView

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -177,7 +177,7 @@ public class FbDialog extends Dialog {
         @Override
         public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
             super.onReceivedSslError(view, handler, error);
-            mListener.onError(new DialogError("SSL error", error.getPrimaryError(), null));
+            mListener.onError(new DialogError("SSL error", WebViewClient.ERROR_FAILED_SSL_HANDSHAKE, null));
             FbDialog.this.dismiss();
         }
 


### PR DESCRIPTION
In case of SSL errors the dialog currently just remains open and the user has no idea that an error has happened.
