### PR TITLE
Fix for force closes where user rotates phone immediately after submitting status update.

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -58,6 +58,8 @@ public class FbDialog extends Dialog {
     private WebView mWebView;
     private FrameLayout mContent;
 
+    private boolean detached = false;
+
     public FbDialog(Context context, String url, DialogListener listener) {
         super(context, android.R.style.Theme_Translucent_NoTitleBar);
         mUrl = url;
@@ -65,6 +67,18 @@ public class FbDialog extends Dialog {
     }
 
     @Override
+    public void onDetachedFromWindow() {
+        detached = true;
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public void dismiss() {
+        if (!detached) {
+            super.dismiss();
+        }
+    }
+
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mSpinner = new ProgressDialog(getContext());
@@ -177,13 +191,17 @@ public class FbDialog extends Dialog {
         public void onPageStarted(WebView view, String url, Bitmap favicon) {
             Log.d("Facebook-WebView", "Webview loading URL: " + url);
             super.onPageStarted(view, url, favicon);
-            mSpinner.show();
+            if (!detached) {
+                mSpinner.show();
+            }
         }
 
         @Override
         public void onPageFinished(WebView view, String url) {
             super.onPageFinished(view, url);
-            mSpinner.dismiss();
+            if (!detached) {
+                mSpinner.dismiss();
+            }
             /* 
              * Once webview is fully loaded, set the mContent background to be transparent
              * and make visible the 'x' image. 


### PR DESCRIPTION
There is a common case where a user rotates the phone immediately
after submitting a status update. This causes the dialog and spinner
to be detached from the window manager. Any subsequent calls to
dismiss() on either the dialog or the spinner will cause the whole
app to force close.

This is easily resolved by implementing the onDetachedFromWindow
callback, and then stopping the dismiss calls.
