### PR TITLE
Expose last access update timestamp.

### DIFF
--- a/examples/Hackbook/src/com/facebook/android/SessionStore.java
+++ b/examples/Hackbook/src/com/facebook/android/SessionStore.java
@@ -24,6 +24,7 @@ public class SessionStore {
 
     private static final String TOKEN = "access_token";
     private static final String EXPIRES = "expires_in";
+    private static final String LAST_UPDATE = "last_update";
     private static final String KEY = "facebook-session";
 
     /*
@@ -35,6 +36,7 @@ public class SessionStore {
         Editor editor = context.getSharedPreferences(KEY, Context.MODE_PRIVATE).edit();
         editor.putString(TOKEN, session.getAccessToken());
         editor.putLong(EXPIRES, session.getAccessExpires());
+        editor.putLong(LAST_UPDATE, session.getLastAccessUpdate());
         return editor.commit();
     }
 
@@ -45,6 +47,7 @@ public class SessionStore {
         SharedPreferences savedSession = context.getSharedPreferences(KEY, Context.MODE_PRIVATE);
         session.setAccessToken(savedSession.getString(TOKEN, null));
         session.setAccessExpires(savedSession.getLong(EXPIRES, 0));
+        session.setLastAccessUpdate(savedSession.getLong(LAST_UPDATE, 0));
         return session.isSessionValid();
     }
 

--- a/examples/simple/src/com/facebook/android/SessionStore.java
+++ b/examples/simple/src/com/facebook/android/SessionStore.java
@@ -25,6 +25,7 @@ public class SessionStore {
     
     private static final String TOKEN = "access_token";
     private static final String EXPIRES = "expires_in";
+    private static final String LAST_UPDATE = "last_update";
     private static final String KEY = "facebook-session";
     
     public static boolean save(Facebook session, Context context) {
@@ -32,6 +33,7 @@ public class SessionStore {
             context.getSharedPreferences(KEY, Context.MODE_PRIVATE).edit();
         editor.putString(TOKEN, session.getAccessToken());
         editor.putLong(EXPIRES, session.getAccessExpires());
+        editor.putLong(LAST_UPDATE, session.getLastAccessUpdate());
         return editor.commit();
     }
 
@@ -40,6 +42,7 @@ public class SessionStore {
             context.getSharedPreferences(KEY, Context.MODE_PRIVATE);
         session.setAccessToken(savedSession.getString(TOKEN, null));
         session.setAccessExpires(savedSession.getLong(EXPIRES, 0));
+        session.setLastAccessUpdate(savedSession.getLong(LAST_UPDATE, 0));
         return session.isSessionValid();
     }
 

--- a/examples/stream/src/com/facebook/stream/Session.java
+++ b/examples/stream/src/com/facebook/stream/Session.java
@@ -31,6 +31,7 @@ public class Session {
 
     private static final String TOKEN = "access_token";
     private static final String EXPIRES = "expires_in";
+    private static final String LAST_UPDATE = "last_update";
     private static final String KEY = "facebook-session";
     private static final String UID = "uid";
     private static final String NAME = "name";
@@ -94,6 +95,7 @@ public class Session {
             context.getSharedPreferences(KEY, Context.MODE_PRIVATE).edit();
         editor.putString(TOKEN, fb.getAccessToken());
         editor.putLong(EXPIRES, fb.getAccessExpires());
+        editor.putLong(LAST_UPDATE, fb.getLastAccessUpdate());
         editor.putString(UID, uid);
         editor.putString(NAME, name);
         editor.putString(APP_ID, fb.getAppId());
@@ -131,6 +133,7 @@ public class Session {
         Facebook fb = new Facebook(appId);
         fb.setAccessToken(prefs.getString(TOKEN, null));
         fb.setAccessExpires(prefs.getLong(EXPIRES, 0));
+        fb.setLastAccessUpdate(prefs.getLong(LAST_UPDATE, 0));
         String uid = prefs.getString(UID, null);
         String name = prefs.getString(NAME, null);
         if (!fb.isSessionValid() || uid == null || name == null) {

--- a/facebook/src/com/facebook/android/Facebook.java
+++ b/facebook/src/com/facebook/android/Facebook.java
@@ -347,6 +347,7 @@ public class Facebook {
                 CookieSyncManager.getInstance().sync();
                 setAccessToken(values.getString(TOKEN));
                 setAccessExpiresIn(values.getString(EXPIRES));
+                setLastAccessUpdate(System.currentTimeMillis());
                 if (isSessionValid()) {
                     Util.logd("Facebook-authorize", "Login Success! access_token="
                             + getAccessToken() + " expires="
@@ -425,6 +426,7 @@ public class Facebook {
                 } else {
                     setAccessToken(data.getStringExtra(TOKEN));
                     setAccessExpiresIn(data.getStringExtra(EXPIRES));
+                    setLastAccessUpdate(System.currentTimeMillis());
                     if (isSessionValid()) {
                         Util.logd("Facebook-authorize",
                                 "Login Success! access_token="
@@ -540,6 +542,7 @@ public class Facebook {
                 if (token != null) {
                     setAccessToken(token);
                     setAccessExpires(expiresAt);
+                    setLastAccessUpdate(System.currentTimeMillis());
                     if (serviceListener != null) {
                         serviceListener.onComplete(resultBundle);
                     }
@@ -626,6 +629,7 @@ public class Facebook {
         String response = request(b);
         setAccessToken(null);
         setAccessExpires(0);
+        setLastAccessUpdate(0);
         return response;
     }
 
@@ -845,13 +849,22 @@ public class Facebook {
     }
 
     /**
+     * Retrieve the current session's last update time (in milliseconds
+     * since Unix epoch), or 0 if the session doesn't exist.
+     *
+     * @return long - session last update time
+     */
+    public long getLastAccessUpdate() {
+        return mLastAccessUpdate;
+    }
+
+    /**
      * Set the OAuth 2.0 access token for API access.
      *
      * @param token - access token
      */
     public void setAccessToken(String token) {
         mAccessToken = token;
-        mLastAccessUpdate = System.currentTimeMillis();
     }
 
     /**
@@ -862,6 +875,20 @@ public class Facebook {
      */
     public void setAccessExpires(long time) {
         mAccessExpires = time;
+    }
+
+    /**
+     * Set the current session's last update time (in milliseconds since Unix
+     * epoch).
+     *
+     * This should be used in conjunction with
+     * {@link Facebook#setAccessToken(String)} to restore a previously saved
+     * session.
+     *
+     * @param time - timestamp in milliseconds
+     */
+    public void setLastAccessUpdate(long time) {
+        mLastAccessUpdate = time;
     }
 
     /**


### PR DESCRIPTION
This commit addresses the first part of [Bug 329021273822477](https://developers.facebook.com/bugs/329021273822477) by introducing a new set of accessors to `com.facebook.android.Facebook`:
- `getLastAccessUpdate()` - retrieves the last time an access token was set/extended
- `setLastAccessUpdate()` - set the last update time for an access token

This prevents `setAccessToken()` from blindly updating `mLastAccessUpdate` when called at application startup to restore a saved session, thus restoring `extendAccessTokenIfNeeded()` functionality.

Bundled examples have been updated to reflect the use case for the new methods.
