### PR TITLE
Don't append access_token to AuthDialogs

### DIFF
--- a/facebook/src/com/facebook/android/Facebook.java
+++ b/facebook/src/com/facebook/android/Facebook.java
@@ -800,11 +800,13 @@ public class Facebook {
             parameters.putString("client_id", mAppId);
         } else {
             parameters.putString("app_id", mAppId);
+            
+            if (isSessionValid()) {
+                parameters.putString(TOKEN, getAccessToken());
+            }
         }
 
-        if (isSessionValid()) {
-            parameters.putString(TOKEN, getAccessToken());
-        }
+
         String url = endpoint + "?" + Util.encodeUrl(parameters);
         if (context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)
                 != PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
Don't append the invalidated access_token to the AuthDialog Url. When doing this, facebook displays an "error" message in place of the auth dialog. The bug can bee seen by authenticating through the Android Browser, then authenticating your application. Then log-out of Facebook. Next time you need to auth within the application, you will see the error dialog. Removing the AuthToken from the AuthDialog fixes this problem. Also, I can not find anywhere in the facebook documentation to append the auth_token to an auth dialog.
