### PR TITLE
Use current app configuration to enable/disable logging

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -51,7 +51,7 @@ public final class Util {
      * Set this to true to enable log output.  Remember to turn this back off
      * before releasing.  Sending sensitive data to log is a security risk.
      */
-    private static boolean ENABLE_LOG = false;
+    private static boolean ENABLE_LOG = BuildConfig.DEBUG;
 
     /**
      * Generate the multi-part post body providing the parameters and boundary


### PR DESCRIPTION
Use the BuildConfig.DEBUG flag to enable logging instead of manually changing a flag.
