### PR TITLE
Clear only facebook.com cookies when logging out

### DIFF
--- a/facebook/src/com/facebook/android/Util.java
+++ b/facebook/src/com/facebook/android/Util.java
@@ -239,8 +239,16 @@ public final class Util {
         @SuppressWarnings("unused")
         CookieSyncManager cookieSyncMngr =
             CookieSyncManager.createInstance(context);
-        CookieManager cookieManager = CookieManager.getInstance();
-        cookieManager.removeAllCookie();
+        String cookieString = cookieManager.getCookie("facebook.com");
+        String[] cookie = cookieString.split("; ");
+        for (int i=0; i<cookie.length; i++){
+            String[] cookiekv = cookie[i].split("=");       
+            if (Arrays.asList(cookiekv).size() == 2) {
+                cookieManager.setCookie("facebook.com", 
+                    cookiekv[0]+ "=; expires=Sat, 1 Jan 2000 00:00:01 UTC");
+            }
+        }
+        cookieManager.removeExpiredCookie();
     }
 
     /**


### PR DESCRIPTION
In the current version of the SDK, all cookies are cleared from the specified context when calling the SDK's logout method.

This can be problematic for applications that use a WebView or have some other reason to maintain cookie state post Facebook logout.

The Android SDK does not provide a method to delete cookies from a single domain, so here is an alternate implementation.

The changes in this pull request do the following:
- Retrieve the cookie string for the domain "facebook.com"
- Split the string to retrieve individual cookies
- Call setCookie() with each key, setting a blank value and an expiration date of 01/01/2000
- Call removeExpiredCookies()
