### PR TITLE
A getter for the permissions used in the last authorize attempt

### DIFF
--- a/facebook/src/com/facebook/android/Facebook.java
+++ b/facebook/src/com/facebook/android/Facebook.java
@@ -859,6 +859,16 @@ public class Facebook {
         return mAccessToken;
     }
 
+	/**
+	 * Retrieve the last permissions that were used in the last authorization attempt
+	 * Returns null if no session exists. Does not explicitly say you are authorized 
+	 * with these permissions but gets you permissions from your last request.
+	 * @return String[] - permissions
+	 */
+	public String[] getPermissions(){
+		return mAuthPermissions;
+	}
+	
     /**
      * Retrieve the current session's expiration time (in milliseconds since
      * Unix epoch), or 0 if the session doesn't expire or doesn't exist.


### PR DESCRIPTION
Added a getter for the permissions used in the last authorize attempt. Useful if you just want a quick way to check what permissions was used in the last request. For example when you want different permissions in different parts of your app and you don't want to hit the network every time to see what permissions you have. There is a possibility that this is out of sync with the real state. Should be used when you are adding additional permissions and just want to check what you asked for last.
