### PR TITLE
DialogListener#onCancel should be triggered in onBackPressed

### DIFF
--- a/facebook/src/com/facebook/android/FbDialog.java
+++ b/facebook/src/com/facebook/android/FbDialog.java
@@ -111,6 +111,12 @@ public class FbDialog extends Dialog {
         mCrossImage.setVisibility(View.INVISIBLE);
     }
 
+    @Override
+    public void onBackPressed() {
+        mListener.onCancel();
+        dismiss();
+    }
+
     private void setUpWebView(int margin) {
         LinearLayout webViewContainer = new LinearLayout(getContext());
         mWebView = new WebView(getContext());


### PR DESCRIPTION
I don't think that the back button behavior should differ from tapping the black X.
