### PR TITLE
Maven compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ facebook/lint.xml
 facebook/tests/lint.xml
 facebook/tests/assets/config.json
 .idea/workspace.xml
+target/

--- a/facebook/pom.xml
+++ b/facebook/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.android</groupId>
+        <artifactId>android-sdk-parent</artifactId>
+        <version>3.0.1.b</version>
+    </parent>
+
+    <artifactId>android-sdk</artifactId>
+
+    <packaging>apklib</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>support-v4</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<project
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.facebook.android</groupId>
+    <artifactId>android-sdk-parent</artifactId>
+    <version>3.0.1.b</version>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>facebook</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <android.plugin.name>android-maven-plugin</android.plugin.name>
+        <android.plugin.version>3.1.1</android.plugin.version>
+
+        <android.platform>15</android.platform>
+        <android.platform.version>2.2.1</android.platform.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.android</groupId>
+                <artifactId>android</artifactId>
+                <version>4.1.1.4</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.android</groupId>
+                <artifactId>support-v4</artifactId>
+                <version>r7</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>android-sdk</artifactId>
+                <version>${project.version}</version>
+                <type>apklib</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <sourceDirectory>src/</sourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.jayway.maven.plugins.android.generation2</groupId>
+                <artifactId>${android.plugin.name}</artifactId>
+                <version>${android.plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <sdk>
+                        <platform>${android.platform}</platform>
+                    </sdk>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Adding pom files to build the facebook android-sdk and install it in the local maven repository.

This adds support for running the build with 'mvn clean install' from the root and as a result having the facebook-android-sdk get installed in your local repository.

Unfortunately, I haven't been able to get the tests to pass locally, so I excluded those from the mvn build for now. With a config.json file, the tests hang on com.facebook.AsyncRequestTests#testBatchUploadPhoto. Without the config.json file, the build completes, but 115/232 tests fail.

Given that neither the build_and_test script nor configure_unit_tests were able to be run out of the box (see #281), I'm not too surprised that I'm having these other testing problems.
