### PR TITLE
Update facebook/src/com/facebook/android/Facebook.java

### DIFF
--- a/facebook/src/com/facebook/android/Facebook.java
+++ b/facebook/src/com/facebook/android/Facebook.java
@@ -101,7 +101,7 @@ public class Facebook {
 
     private Activity mAuthActivity;
     private String[] mAuthPermissions;
-    private int mAuthActivityCode;
+    private int mAuthActivityCode = DEFAULT_AUTH_ACTIVITY_CODE;
     private DialogListener mAuthDialogListener;
     
     // If the last time we extended the access token was more than 24 hours ago


### PR DESCRIPTION
initialise mAuthActivityCode with DEFAULT_AUTH_ACTIVITY_CODE to prevent NPE when launching an non-facebook activity with startActivityForResult and a requestCode to 0. In that case, if facebook code is present in the onActivityResult, it will be launched and mAuthActivityCode (=0 because not initialised) will be compared to requestCode (=0) then null objects will be called.
