### PR TITLE
Add Session.OpenActiveSession() that takes permissions

### DIFF
--- a/facebook/src/com/facebook/Session.java
+++ b/facebook/src/com/facebook/Session.java
@@ -964,6 +964,30 @@ public class Session implements Serializable {
     }
 
     /**
+     * If allowLoginUI is true, this will create a new Session, make it active, and
+     * open it. If the default token cache is not available, then this will request
+     * basic permissions. If the default token cache is available and cached tokens
+     * are loaded, this will use the cached token and associated permissions.
+     * <p/>
+     * If allowedLoginUI is false, this will only create the active session and open
+     * it if it requires no user interaction (i.e. the token cache is available and
+     * there are cached tokens).
+     *
+     * @param context      The Activity or Service creating this Session
+     * @param fragment     The Fragment that is opening the new Session.
+     * @param allowLoginUI if false, only sets the active session and opens it if it
+     *                     does not require user interaction
+     * @param callback     The {@link StatusCallback SessionStatusCallback} to
+     *                     notify regarding Session state changes.
+     * @param permissions  The permissions to request.
+     * @return The new Session or null if one could not be created
+     */
+    public static Session openActiveSession(Context context, Fragment fragment,
+            boolean allowLoginUI, StatusCallback callback, List<String> permissions) {
+        return openActiveSession(context, allowLoginUI, new OpenRequest(fragment).setCallback(callback).setPermissions(permissions));
+    }
+
+    /**
      * Opens a session based on an existing Facebook access token, and also makes this session
      * the currently active session. This method should be used
      * only in instances where an application has previously obtained an access token and wishes


### PR DESCRIPTION
I noticed when a using a similar bit of code to the SessionLoginSample if the user canceled the login and then tried to do the login again, the openActiveSession() call would not preserve the permissions.
