### PR TITLE
Fix for java.lang.NullPointerException: println needs a message in Utility.logd

### DIFF
--- a/facebook/src/com/facebook/Session.java
+++ b/facebook/src/com/facebook/Session.java
@@ -1486,7 +1486,7 @@ public class Session implements Serializable {
             try {
                 Settings.publishInstallAndWait(mApplicationContext, mApplicationId);
             } catch (Exception e) {
-                Utility.logd("Facebook-publish", e.getMessage());
+                Utility.logd("Facebook-publish", e.getClass().getSimpleName() + ": " + e.getMessage());
             }
             return null;
         }

--- a/facebook/src/com/facebook/Settings.java
+++ b/facebook/src/com/facebook/Settings.java
@@ -288,7 +288,7 @@ public final class Settings {
             return lastPing != 0;
         } catch (Exception e) {
             // if there was an error, fall through to the failure case.
-            Utility.logd("Facebook-publish", e.getMessage());
+            Utility.logd("Facebook-publish", e.getClass().getSimpleName() + ": " + e.getMessage());
         }
         return false;
     }


### PR DESCRIPTION
If Android's Log gets called with a null argument it will cause the NPE in the title. This can happen in two places in the Facebook SDK when Utility.logd gets called with e.getMessage() which can be null. This pull requests prevents this issue from happening
