### PR TITLE
Workaround for http://developers.facebook.com/bugs/340568486052002

### DIFF
--- a/facebook/src/com/facebook/NativeProtocol.java
+++ b/facebook/src/com/facebook/NativeProtocol.java
@@ -235,10 +235,13 @@ final class NativeProtocol {
     }
 
     static boolean isServiceDisabledResult20121101(Intent data) {
-        int protocolVersion = data.getIntExtra(EXTRA_PROTOCOL_VERSION, 0);
-        String errorType = data.getStringExtra(STATUS_ERROR_TYPE);
+        if (data != null) {
+            int protocolVersion = data.getIntExtra(EXTRA_PROTOCOL_VERSION, 0);
+            String errorType = data.getStringExtra(STATUS_ERROR_TYPE);
 
-        return ((PROTOCOL_VERSION_20121101 == protocolVersion) && ERROR_SERVICE_DISABLED.equals(errorType));
+            return ((PROTOCOL_VERSION_20121101 == protocolVersion) && ERROR_SERVICE_DISABLED.equals(errorType));
+        }
+        return true;
     }
 
     static AccessTokenSource getAccessTokenSourceFromNative(Bundle extras) {


### PR DESCRIPTION
We see crash reports in production where the Intent passed to isServiceDisabledResult20121101 is null which cause an NPE. The added null safeguard in this pull request prevents the crash and lets the Authentication fall back to the next handler
