### PR TITLE
When opening a PickerFragment, allow passing a set of ids to be selected

### DIFF
--- a/facebook/src/com/facebook/widget/PickerFragment.java
+++ b/facebook/src/com/facebook/widget/PickerFragment.java
@@ -94,6 +94,7 @@ public abstract class PickerFragment<T extends GraphObject> extends Fragment {
     private final Class<T> graphObjectClass;
     private LoadingStrategy loadingStrategy;
     private SelectionStrategy selectionStrategy;
+    private Set<String> selectionHint;
     private ProgressBar activityCircle;
     private SessionTracker sessionTracker;
     private String titleText;
@@ -472,9 +473,21 @@ public abstract class PickerFragment<T extends GraphObject> extends Fragment {
      *                    if false, data will not be re-loaded if it is already displayed (or loading)
      */
     public void loadData(boolean forceReload) {
+        loadData(forceReload, null);
+    }
+
+    /**
+     * Causes the picker to load data from the service and display it to the user.
+     *
+     * @param forceReload if true, data will be loaded even if there is already data being displayed (or loading);
+     *                    if false, data will not be re-loaded if it is already displayed (or loading)
+     * @param selectIds ids to select, if they are present in the loaded data
+     */
+    public void loadData(boolean forceReload, Set<String> selectIds) {
         if (!forceReload && loadingStrategy.isDataPresentOrLoading()) {
             return;
         }
+        selectionHint = selectIds;
         loadDataSkippingRoundTripIfCached();
     }
 
@@ -718,6 +731,29 @@ public abstract class PickerFragment<T extends GraphObject> extends Fragment {
 
             if (dataChanged && onDataChangedListener != null) {
                 onDataChangedListener.onDataChanged(PickerFragment.this);
+            }
+            if (selectionHint != null && !selectionHint.isEmpty() && data != null) {
+                data.moveToFirst();
+                boolean changed = false;
+                for (int i = 0; i < data.getCount(); i++) {
+                    data.moveToPosition(i);
+                    T graphObject = data.getGraphObject();
+                    if (!graphObject.asMap().containsKey("id"))
+                        continue;
+                    Object obj = graphObject.getProperty("id");
+                    if (!(obj instanceof String)) {
+                        continue;
+                    }
+                    String id = (String) obj;
+                    if (selectionHint.contains(id)) {
+                        selectionStrategy.toggleSelection(id);
+                        selectionHint.remove(id);
+                        changed = true;
+                    }
+                }
+                if (onSelectionChangedListener != null && changed) {
+                    onSelectionChangedListener.onSelectionChanged(PickerFragment.this);
+                }
             }
         }
     }


### PR DESCRIPTION
This avoids having to redo the selection if the user wants to adjust the selection only slightly, e.g. adding/removing one single user from a friend picker.
