### PR TITLE
Fix NPE in Webdialog for some Motorola 2.2 devices

### DIFF
--- a/facebook/src/com/facebook/widget/WebDialog.java
+++ b/facebook/src/com/facebook/widget/WebDialog.java
@@ -264,7 +264,18 @@ public class WebDialog extends Dialog {
     @SuppressLint("SetJavaScriptEnabled")
     private void setUpWebView(int margin) {
         LinearLayout webViewContainer = new LinearLayout(getContext());
-        webView = new WebView(getContext());
+        webView = new WebView(getContext()) {
+        	/* Prevent NPE on Motorola 2.2 devices
+        	 * See https://groups.google.com/forum/?fromgroups=#!topic/android-developers/ktbwY2gtLKQ
+        	*/
+        	@Override
+        	public void onWindowFocusChanged(boolean hasWindowFocus) {
+        		try {
+        			super.onWindowFocusChanged(hasWindowFocus);
+        		} catch (NullPointerException e) {
+        		}
+        	}
+        };
         webView.setVerticalScrollBarEnabled(false);
         webView.setHorizontalScrollBarEnabled(false);
         webView.setWebViewClient(new DialogWebViewClient());


### PR DESCRIPTION
The web authorization dialog crashes on some Android 2.2 Motorola devices with a NPE.
This fix prevents the NPE.

https://groups.google.com/forum/?fromgroups=#!topic/android-developers/ktbwY2gtLKQ
