### PR TITLE
Always use the expected Locale when formatting an api parameter string

### DIFF
--- a/facebook/src/com/facebook/widget/GraphObjectAdapter.java
+++ b/facebook/src/com/facebook/widget/GraphObjectAdapter.java
@@ -432,7 +432,7 @@ class GraphObjectAdapter<T extends GraphObject> extends BaseAdapter implements S
 
         // Note: these dimensions are in pixels, not dips
         ViewGroup.LayoutParams layoutParams = picture.getLayoutParams();
-        return String.format("picture.height(%d).width(%d)", layoutParams.height, layoutParams.width);
+        return String.format(Locale.US, "picture.height(%d).width(%d)", layoutParams.height, layoutParams.width);
     }
 
 


### PR DESCRIPTION
This fixes exceptions that appeared when the device locale is set to for
example arabic, which formats integer numbers using eastern arabic glyphs.
