### PR TITLE
ClassCastException on ApplicationId

### DIFF
--- a/facebook/src/com/facebook/internal/Utility.java
+++ b/facebook/src/com/facebook/internal/Utility.java
@@ -162,7 +162,7 @@ public final class Utility {
             ApplicationInfo ai = context.getPackageManager().getApplicationInfo(
                     context.getPackageName(), PackageManager.GET_META_DATA);
             if (ai.metaData != null) {
-                return ai.metaData.getString(Session.APPLICATION_ID_PROPERTY);
+                return ai.metaData.get(Session.APPLICATION_ID_PROPERTY).toString();
             }
         } catch (PackageManager.NameNotFoundException e) {
             // if we can't find it in the manifest, just return null


### PR DESCRIPTION
This fixes the ClassCastException that happens when using

`<meta-data android:name="com.facebook.sdk.ApplicationId" android:resource="@string/facebook_app_id" />`

in place of

`<meta-data android:name="com.facebook.sdk.ApplicationId" android:value="123456" />`

in AndroidManifest.xml.

```
05-24 08:03:15.083    1219-1219/?                              W/Bundle: Key com.facebook.sdk.ApplicationId expected String but value was a java.lang.Integer.  The default value <null> was returned.
05-24 08:03:15.103    1219-1219/?                              W/Bundle: Attempt to cast generated internal exception:
        java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
        at android.os.Bundle.getString(Bundle.java:1069)
        at com.facebook.internal.Utility.getMetadataApplicationId(Utility.java:165)
        at com.facebook.Session.<init>(Session.java:221)
        at com.facebook.Session.<init>(Session.java:213)
        at com.facebook.Session$Builder.build(Session.java:1454)
        at com.facebook.Session.openActiveSession(Session.java:863)
        at com.facebook.Session.openActiveSessionFromCache(Session.java:783)
        at myapp.activity.MyActivity.goToNextActivity(MyActivity.java:72)
        at myapp.activity.MyActivity.access$100(MyActivity.java:22)
        at myapp.activity.MyActivity$2.onClick(MyActivity.java:50)
        at com.android.internal.app.AlertController$ButtonHandler.handleMessage(AlertController.java:166)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:137)
        at android.app.ActivityThread.main(ActivityThread.java:5041)
        at java.lang.reflect.Method.invokeNative(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:511)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
        at dalvik.system.NativeStart.main(Native Method)
05-24 08:03:15.103    1219-1219/?                              D/AndroidRuntime: Shutting down VM
05-24 08:03:15.103    1219-1219/?                              W/dalvikvm: threadid=1: thread exiting with uncaught exception (group=0x40a71930)
05-24 08:03:15.133    1219-1219/?                              E/AndroidRuntime: FATAL EXCEPTION: main
        java.lang.NullPointerException: Argument 'applicationId' cannot be null
        at com.facebook.internal.Validate.notNull(Validate.java:29)
        at com.facebook.Session.<init>(Session.java:224)
        at com.facebook.Session.<init>(Session.java:213)
        at com.facebook.Session$Builder.build(Session.java:1454)
        at com.facebook.Session.openActiveSession(Session.java:863)
        at com.facebook.Session.openActiveSessionFromCache(Session.java:783)
        at myapp.activity.MyActivity.goToNextActivity(MyActivity.java:72)
        at myapp.activity.MyActivity.access$100(MyActivity.java:22)
        at myapp.activity.MyActivity$2.onClick(MyActivity.java:50)
        at com.android.internal.app.AlertController$ButtonHandler.handleMessage(AlertController.java:166)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:137)
        at android.app.ActivityThread.main(ActivityThread.java:5041)
        at java.lang.reflect.Method.invokeNative(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:511)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
        at dalvik.system.NativeStart.main(Native Method)
```
