### PR TITLE
fix force close when configuration change

### DIFF
--- a/facebook/src/com/facebook/AuthorizationClient.java
+++ b/facebook/src/com/facebook/AuthorizationClient.java
@@ -717,6 +717,10 @@ class AuthorizationClient implements Serializable {
             }
         }
 
+        boolean needsRestart() {
+            return true;
+        }
+
         boolean tryAuthorize(final AuthorizationRequest request) {
             getTokenClient = new GetTokenClient(context, request.getApplicationId());
             if (!getTokenClient.start()) {

--- a/facebook/src/com/facebook/LoginActivity.java
+++ b/facebook/src/com/facebook/LoginActivity.java
@@ -62,8 +62,8 @@ public class LoginActivity extends Activity {
         } else {
             callingPackage = getCallingPackage();
             authorizationClient = new AuthorizationClient();
-            request = (AuthorizationClient.AuthorizationRequest) getIntent().getSerializableExtra(EXTRA_REQUEST);
         }
+        request = (AuthorizationClient.AuthorizationRequest) getIntent().getSerializableExtra(EXTRA_REQUEST);
 
         authorizationClient.setContext(this);
         authorizationClient.setOnCompletedListener(new AuthorizationClient.OnCompletedListener() {


### PR DESCRIPTION
1.Fix when user rotate the screen when login is in progress or the permission dialog, it cause force close because the request in LoginActivity is null
2.When LoginActivity enter onPause during GetTokenAuthHandler get token and before is complete and enter onResume again, the screen is freeze because LoginActivity didn't finish. LoginActivity is transparent and has no button to finish, there will be no response when user touch the screen. User needs to click back button to close LoginActivity. 
