### PR TITLE
Update RequestAsyncTask.java

### DIFF
--- a/facebook/src/com/facebook/RequestAsyncTask.java
+++ b/facebook/src/com/facebook/RequestAsyncTask.java
@@ -177,13 +177,14 @@ public class RequestAsyncTask extends AsyncTask<Void, Void, List<Response>> {
                 executeOnExecutorMethod.invoke(this, Settings.getExecutor(), null);
                 return this;
             }
+            else {
+                this.execute();
+                return this;
+            }
         } catch (InvocationTargetException e) {
             // fall-through
         } catch (IllegalAccessException e) {
             // fall-through
         }
-
-        this.execute();
-        return this;
     }
 }


### PR DESCRIPTION
RequestAsyncTask.executeOnSettingsExecutor has a mistake in it.
If executeOnExecutorMethod.invoke will throw InvocationTargetException or IllegalAccessException, function this.execute() will be called, right after AsyncTask status will be changed to RUNNING, and then this.execute() will throw IllegalStateException
