### PR TITLE
Update NativeProtocol.java

### DIFF
--- a/facebook/src/com/facebook/internal/NativeProtocol.java
+++ b/facebook/src/com/facebook/internal/NativeProtocol.java
@@ -372,23 +372,26 @@ public final class NativeProtocol {
         if (c == null) {
             return NO_PROTOCOL_AVAILABLE;
         }
-
-        Set<Integer> versions = new HashSet<Integer>();
-        while (c.moveToNext()) {
-            int version = c.getInt(c.getColumnIndex(PLATFORM_PROVIDER_VERSION_COLUMN));
-            versions.add(version);
-        }
-
-        for (Integer knownVersion : KNOWN_PROTOCOL_VERSIONS) {
-            if (knownVersion < minimumVersion) {
-                return NO_PROTOCOL_AVAILABLE;
+        try {
+            Set<Integer> versions = new HashSet<Integer>();
+            while (c.moveToNext()) {
+                int version = c.getInt(c.getColumnIndex(PLATFORM_PROVIDER_VERSION_COLUMN));
+                versions.add(version);
             }
-
-            if (versions.contains(knownVersion)) {
-                return knownVersion;
+    
+            for (Integer knownVersion : KNOWN_PROTOCOL_VERSIONS) {
+                if (knownVersion < minimumVersion) {
+                    return NO_PROTOCOL_AVAILABLE;
+                }
+    
+                if (versions.contains(knownVersion)) {
+                    return knownVersion;
+                }
             }
+    
+            return NO_PROTOCOL_AVAILABLE;
+        } finally {
+            c.close();
         }
-
-        return NO_PROTOCOL_AVAILABLE;
     }
 }


### PR DESCRIPTION
Cursor may leak. Here is the stack trace that I got when using the sdk:

01-27 14:35:53.280    8918-8927/? E/StrictMode﹕ A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
    java.lang.Throwable: Explicit termination method 'close' not called
            at dalvik.system.CloseGuard.open(CloseGuard.java:184)
            at android.content.ContentResolver$CursorWrapperInner.<init>(ContentResolver.java:2255)
            at android.content.ContentResolver.query(ContentResolver.java:485)
            at android.content.ContentResolver.query(ContentResolver.java:404)
            at com.facebook.internal.NativeProtocol.getLatestAvailableProtocolVersion(NativeProtocol.java:371)
            at com.facebook.internal.PlatformServiceClient.start(PlatformServiceClient.java:73)
            at com.facebook.AuthorizationClient$GetTokenAuthHandler.tryAuthorize(AuthorizationClient.java:732)
            at com.facebook.AuthorizationClient.tryCurrentHandler(AuthorizationClient.java:268)
            at com.facebook.AuthorizationClient.tryNextHandler(AuthorizationClient.java:234)
            at com.facebook.AuthorizationClient.authorize(AuthorizationClient.java:157)
            at com.facebook.AuthorizationClient.startOrContinueAuth(AuthorizationClient.java:138)
            at com.facebook.LoginActivity.onResume(LoginActivity.java:117)
            at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1192)
            at android.app.Activity.performResume(Activity.java:5310)
            at android.app.ActivityThread.performResumeActivity(ActivityThread.java:2778)
            at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:2817)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2250)
            at android.app.ActivityThread.access$800(ActivityThread.java:135)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1196)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:136)
            at android.app.ActivityThread.main(ActivityThread.java:5017)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:515)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:779)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:595)
            at dalvik.system.NativeStart.main(Native Method)
