### PR TITLE
AppLinkData: Fix use of wrong operator in string comparison

### DIFF
--- a/facebook/src/com/facebook/AppLinkData.java
+++ b/facebook/src/com/facebook/AppLinkData.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
 import android.util.Log;
 import com.facebook.internal.*;
 import com.facebook.model.GraphObject;
@@ -150,7 +151,7 @@ public class AppLinkData {
                 final String appLinkClassName = jsonResponse.optString(DEFERRED_APP_LINK_CLASS_FIELD);
                 final String appLinkUrl = jsonResponse.optString(DEFERRED_APP_LINK_URL_FIELD);
 
-                if (appLinkArgsJsonString != null && appLinkArgsJsonString != "") {
+                if (!TextUtils.isEmpty(appLinkArgsJsonString)) {
                     appLinkData = createFromJson(appLinkArgsJsonString);
 
                     if (tapTimeUtc != -1) {


### PR DESCRIPTION
Instead of "!=" we should use "equals()". However, as we also need to
check for "null" here, use the more convenient "TextUtils.isEmpty()".
