### PR TITLE
Add 'repositories' declaration

### DIFF
--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'android-library'
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile 'com.android.support:support-v4:20.0.+'
     compile 'com.parse.bolts:bolts-android:1.1.2'


### PR DESCRIPTION
Otherwise you have to provide `allProjects{...}` or `project('facebook').repositories{...}` to make dependencies (e.g. bolts) to be found – allProjects makes projects coupled (and slows gradle build), and project().repositories injection is ugly as well.
