### PR TITLE
use resource from own package

### DIFF
--- a/facebook/src/com/facebook/internal/ImageDownloader.java
+++ b/facebook/src/com/facebook/internal/ImageDownloader.java
@@ -21,6 +21,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Handler;
 import android.os.Looper;
+import com.facebook.android.R;
 import com.facebook.FacebookException;
 
 import java.io.IOException;


### PR DESCRIPTION
I use sdk-version-3.20.0 tag as a gradle module.
Such error came out when I build.

```
/Users/waka/projects/app/modules/facebook/facebook/src/com/facebook/internal/ImageDownloader.java:262: エラー: パッケージRは存在しません
                        errorMessageBuilder.append(R.string.com_facebook_image_download_unknown_error);
```
