### PR TITLE
Facebook Android SDK 3.20.1

### DIFF
--- a/facebook/src/com/facebook/FacebookSdkVersion.java
+++ b/facebook/src/com/facebook/FacebookSdkVersion.java
@@ -17,5 +17,5 @@
 package com.facebook;
 
 final class FacebookSdkVersion {
-    public static final String BUILD = "3.19.1";
+    public static final String BUILD = "3.20.1";
 }


### PR DESCRIPTION
Since `3.19.1` wasn't changed to `3.20.0`, I believe that next push will be with `3.20.1` :)
