### PR TITLE
correct the login class name in the log line

### DIFF
--- a/facebook/src/com/facebook/login/LoginManager.java
+++ b/facebook/src/com/facebook/login/LoginManager.java
@@ -380,7 +380,8 @@ public class LoginManager {
 
         if (!started) {
             FacebookException exception = new FacebookException(
-                    "Log in attempt failed: LoginActivity could not be started");
+                    "Log in attempt failed: FacebookActivity could not be started."
+                    + " Please make sure you added FacebookActivity to the AndroidManifest.");
             logCompleteLogin(LoginClient.Result.Code.ERROR, null, exception);
             this.pendingLoginRequest = null;
             throw exception;


### PR DESCRIPTION
Also, remind user to add the class to manifest.
This error can make developers run in loops for hours without realising which class name they have forgotten to add in their manifest.