### PR TITLE
fix the leak with webview

### DIFF
--- a/facebook/src/com/facebook/internal/WebDialog.java
+++ b/facebook/src/com/facebook/internal/WebDialog.java
@@ -378,7 +378,7 @@ public class WebDialog extends Dialog {
     @SuppressLint("SetJavaScriptEnabled")
     private void setUpWebView(int margin) {
         LinearLayout webViewContainer = new LinearLayout(getContext());
-        webView = new WebView(getContext()) {
+        webView = new WebView(getContext().getApplicationContext()) {
             /* Prevent NPE on Motorola 2.2 devices
              * See https://groups.google.com/forum/?fromgroups=#!topic/android-developers/ktbwY2gtLKQ
              */


### PR DESCRIPTION
If the user doesn't have the Facebook app installed, he/she will use webview to login/share. The webview is initialized with activity context instead of application context. So, the WeakHashMap cache inside ResourcesContextWrapperFactory will end up retaining a reference to the FacebookActivity forever. More details about the issue here: 
https://code.google.com/p/chromium/issues/detail?id=473146