### PR TITLE
unwrap multiple levels of ContextWrapper

### DIFF
--- a/facebook/src/com/facebook/FacebookButtonBase.java
+++ b/facebook/src/com/facebook/FacebookButtonBase.java
@@ -167,14 +167,12 @@ public abstract class FacebookButtonBase extends Button {
     }
 
     protected Activity getActivity() {
-        final Context context = getContext();
+        Context context = getContext();
+        while (!(context instanceof Activity) && context instanceof ContextWrapper) {
+            context = ((ContextWrapper) context).getBaseContext();
+        }
         if (context instanceof Activity) {
             return (Activity) context;
-        } else if (context instanceof ContextWrapper) {
-            Context baseContext = ((ContextWrapper) context).getBaseContext();
-            if (baseContext instanceof Activity) {
-                return (Activity) baseContext;
-            }
         }
         throw new FacebookException("Unable to get Activity.");
     }


### PR DESCRIPTION
Making getActivity support multilevel ContextWrapper to support passing extra information through multi-layered contextwrapping. (https://github.com/square/flow also uses contextwrapper to pass information this way)