### PR TITLE
Fix buck build

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -7,8 +7,8 @@
     src_roots = /facebook/src/, /samples/HelloFacebookSample/src/
 
     # We target gingerbread. Ensure that libraries target that.
-    source_level = 6
-    target_level = 6
+    source_level = 7
+    target_level = 7
 
 [build]
     build_dependencies = FIRST_ORDER_ONLY

--- a/libs/BUCK
+++ b/libs/BUCK
@@ -8,7 +8,7 @@ prebuilt_jar(
 
 prebuilt_jar(
   name = 'bolts',
-  binary_jar = 'bolts.jar',
+  binary_jar = 'bolts-android-1.1.2.jar',
   visibility = [
     'PUBLIC',
   ],


### PR DESCRIPTION
Summary:
Fix bolts jar filename in libs/ and update to Java 1.7.

Test Plan:
buck clean
buck build sdk

Blame Revision: D1512256
Blame Commit: d075400