### PR TITLE
There is no Facebook Main Library Folder in Latest 4.2 Commit ??

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: android
 android:
   components:
     - build-tools-21.1.2
-    - build-tools-21.0.2
+    - build-tools-22.0.1
     - android-18
-    - android-21
+    - android-22
     - extra
 
 # Override the install and test so that we don't run integration tests


### PR DESCRIPTION
There is no Facebook Main Library Folder in Latest 4.2 Commit only samples folders are there?? 