### PR TITLE
Fix memory leak in LoginManager

### DIFF
--- a/facebook/src/com/facebook/login/LoginManager.java
+++ b/facebook/src/com/facebook/login/LoginManager.java
@@ -355,7 +355,7 @@ public class LoginManager {
 
         this.pendingLoginRequest = request;
         this.pendingLoggingExtras = new HashMap<>();
-        this.context = startActivityDelegate.getActivityContext();
+        this.context = startActivityDelegate.getActivityContext().getApplicationContext();
 
         logStartLogin();
 
@@ -509,10 +509,6 @@ public class LoginManager {
                 callback.onSuccess(loginResult);
             }
         }
-
-        // Cleanup saved context to avoid leaking
-        this.context = null;
-        this.loginLogger = null;
     }
 
     private static class ActivityStartActivityDelegate implements StartActivityDelegate {


### PR DESCRIPTION
LoginManager leaked the calling activity by referencing it with context and loginLogger. This leak was only fixed in case of a successful login, but not when the login was canceled.

Actually there is no need to hold a reference to the calling activity as a reference to the application context is sufficient.