### PR TITLE
Clean pending request after login execution

### DIFF
--- a/facebook/src/com/facebook/login/LoginManager.java
+++ b/facebook/src/com/facebook/login/LoginManager.java
@@ -511,6 +511,8 @@ public class LoginManager {
                 callback.onSuccess(loginResult);
             }
         }
+
+        pendingLoginRequest = null;
     }
 
     private static class ActivityStartActivityDelegate implements StartActivityDelegate {


### PR DESCRIPTION
No reason to keep pending login request after login execution