### PR TITLE
Support applicationId prefixed with "fb"

### DIFF
--- a/facebook/junitTests/src/test/java/com/facebook/FacebookSdkPowerMockTest.java
+++ b/facebook/junitTests/src/test/java/com/facebook/FacebookSdkPowerMockTest.java
@@ -128,7 +128,7 @@ public final class FacebookSdkPowerMockTest extends FacebookPowerMockTestCase {
     private Context mockContextWithAppIdAndClientToken() throws Exception {
         Bundle bundle = mock(Bundle.class);
 
-        when(bundle.get(FacebookSdk.APPLICATION_ID_PROPERTY)).thenReturn("1234");
+        when(bundle.getString(FacebookSdk.APPLICATION_ID_PROPERTY)).thenReturn("1234");
         when(bundle.getString(FacebookSdk.CLIENT_TOKEN_PROPERTY)).thenReturn("abcd");
         ApplicationInfo applicationInfo = mock(ApplicationInfo.class);
         applicationInfo.metaData = bundle;

--- a/facebook/src/com/facebook/FacebookSdk.java
+++ b/facebook/src/com/facebook/FacebookSdk.java
@@ -618,7 +618,12 @@ public final class FacebookSdk {
         if (applicationId == null) {
             Object appId = ai.metaData.get(APPLICATION_ID_PROPERTY);
             if (appId instanceof String) {
-                applicationId = (String) appId;
+                String appIdString = (String) appId;
+                if(appIdString.startsWith("fb")){
+                    applicationId = appIdString.substring(2);
+                }else {
+                    applicationId = appIdString;
+                }
             } else if (appId instanceof Integer) {
                 applicationId = appId.toString();
             }

--- a/facebook/src/com/facebook/FacebookSdk.java
+++ b/facebook/src/com/facebook/FacebookSdk.java
@@ -614,18 +614,11 @@ public final class FacebookSdk {
         if (ai == null || ai.metaData == null) {
             return;
         }
-
+        
         if (applicationId == null) {
-            Object appId = ai.metaData.get(APPLICATION_ID_PROPERTY);
-            if (appId instanceof String) {
-                String appIdString = (String) appId;
-                if(appIdString.startsWith("fb")){
-                    applicationId = appIdString.substring(2);
-                }else {
-                    applicationId = appIdString;
-                }
-            } else if (appId instanceof Integer) {
-                applicationId = appId.toString();
+            applicationId = ai.metaData.getString(APPLICATION_ID_PROPERTY);
+            if(applicationId != null && applicationId.startsWith("fb")){
+                applicationId = applicationId.substring(2);
             }
         }
 


### PR DESCRIPTION
It would be great to have opportunity to force applicationId to be string. Otherwise if you specify applicationId directly through Android manifest (not through constant in strings.xml file) it will overflow to 32-bit int instead of string. I suggest to support also applicationIds with prefix "fb" which will ensure that it will be parsed to string correctly. It will be also similar to CFBundleURLSchemes in iOS version of SDK which is also prefixed by "fb". 