### PR TITLE
-added missing CREATOR to parcelable class AppInviteContent

### DIFF
--- a/facebook/src/com/facebook/share/model/AppInviteContent.java
+++ b/facebook/src/com/facebook/share/model/AppInviteContent.java
@@ -62,6 +62,18 @@ public final class AppInviteContent implements ShareModel {
         out.writeString(this.previewImageUrl);
     }
 
+    @SuppressWarnings("unused")
+    public static final Creator<AppInviteContent> CREATOR =
+        new Creator<AppInviteContent>() {
+            public AppInviteContent createFromParcel(final Parcel in) {
+                return new AppInviteContent(in);
+            }
+
+            public AppInviteContent[] newArray(final int size) {
+            return new AppInviteContent[size];
+        }
+    };
+
     /**
      * Builder class for a concrete instance of AppInviteContent
      */


### PR DESCRIPTION
I used this class in Activity and it crashed my application because it is missing CREATOR http://developer.android.com/reference/android/os/Parcelable.html.