### PR TITLE
Close a CloseCallbackOutputStream to prevent potential resource leak.

### DIFF
--- a/facebook/src/com/facebook/internal/FileLruCache.java
+++ b/facebook/src/com/facebook/internal/FileLruCache.java
@@ -239,6 +239,7 @@ public final class FileLruCache {
         } finally {
             if (!success) {
                 buffered.close();
+                cleanup.close();
             }
         }
     }


### PR DESCRIPTION
This was found using Infer from Facebook.

The issue is that the CloseCallbackOutputStream is not closed and is therefore a resource leak. This patch fixes the issue.