### PR TITLE
Actually return identifiers so method actually works.

### DIFF
--- a/facebook/src/com/facebook/internal/AttributionIdentifiers.java
+++ b/facebook/src/com/facebook/internal/AttributionIdentifiers.java
@@ -134,6 +134,7 @@ public class AttributionIdentifiers {
             identifiers.limitTracking = (Boolean) Utility.invokeMethodQuietly(
                     advertisingInfo,
                     isLimitAdTrackingEnabled);
+            return identifiers;
         } catch (Exception e) {
             Utility.logd("android_id", e);
         }


### PR DESCRIPTION
This is currently breaking our app's request for custom audience third party IDs.