### PR TITLE
Add missing travis ci components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ android:
   components:
     - build-tools-21.1.2
     - build-tools-21.0.2
+    - build-tools-23.0.1
     - android-18
     - android-21
+    - android-23
     - extra
 
 # Override the install and test so that we don't run integration tests


### PR DESCRIPTION
When target sdk was changed to v23 travis ci components were not updated.