### PR TITLE
Add null check on attributionIdentifiers to prevent null pointer exceptions

### DIFF
--- a/facebook/src/com/facebook/GraphRequest.java
+++ b/facebook/src/com/facebook/GraphRequest.java
@@ -604,6 +604,9 @@ public class GraphRequest {
         Bundle parameters = new Bundle();
 
         if (accessToken == null) {
+            if (attributionIdentifiers == null) {
+                throw new FacebookException("There is no access token and attribution identifiers could not be retrieved");
+            }
             // Only use the attributionID if we don't have an access token.  If we do, then the user
             // token will be used to identify the user, and is more reliable than the attributionID.
             String udid = attributionIdentifiers.getAttributionId() != null
@@ -617,7 +620,7 @@ public class GraphRequest {
         // Server will choose to not provide the App User ID in the event that event usage has been
         // limited for this user for this app.
         if (FacebookSdk.getLimitEventAndDataUsage(context)
-                || attributionIdentifiers.isTrackingLimited()) {
+                || (attributionIdentifiers != null && attributionIdentifiers.isTrackingLimited())) {
             parameters.putString("limit_event_usage", "1");
         }
 


### PR DESCRIPTION
…udid is causing NPE crashes

<img width="720" alt="screen shot 2015-10-14 at 5 27 06 pm" src="https://cloud.githubusercontent.com/assets/5994871/10499840/e083c91c-7298-11e5-8ebe-a42529dd5909.png">