### PR TITLE
Always pick up a WebDialog theme set as meta-data in manifest, not on…

### DIFF
--- a/facebook/src/com/facebook/FacebookSdk.java
+++ b/facebook/src/com/facebook/FacebookSdk.java
@@ -38,6 +38,7 @@ import com.facebook.internal.AttributionIdentifiers;
 import com.facebook.internal.NativeProtocol;
 import com.facebook.internal.Utility;
 import com.facebook.internal.Validate;
+import com.facebook.internal.WebDialog;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -728,7 +729,7 @@ public final class FacebookSdk {
      * @param theme A theme to use
      */
     public static void setWebDialogTheme(int theme) {
-        webDialogTheme = theme;
+        webDialogTheme = (theme != 0) ? theme : WebDialog.DEFAULT_THEME;
     }
 
     /**

--- a/facebook/src/com/facebook/internal/WebDialog.java
+++ b/facebook/src/com/facebook/internal/WebDialog.java
@@ -113,7 +113,7 @@ public class WebDialog extends Dialog {
      *                be a valid URL pointing to a Facebook Web Dialog
      */
     public WebDialog(Context context, String url) {
-        this(context, url, DEFAULT_THEME);
+        this(context, url, FacebookSdk.getWebDialogTheme());
     }
 
     /**
@@ -125,7 +125,7 @@ public class WebDialog extends Dialog {
      * @param theme   identifier of a theme to pass to the Dialog class
      */
     public WebDialog(Context context, String url, int theme) {
-        super(context, theme == 0 ? DEFAULT_THEME : theme);
+        super(context, theme == 0 ? FacebookSdk.getWebDialogTheme() : theme);
         this.url = url;
     }
 
@@ -139,7 +139,7 @@ public class WebDialog extends Dialog {
      * @param listener the listener to notify, or null if no notification is desired
      */
     public WebDialog(Context context, String action, Bundle parameters, int theme, OnCompleteListener listener) {
-        super(context, theme == 0 ? DEFAULT_THEME : theme);
+        super(context, theme == 0 ? FacebookSdk.getWebDialogTheme() : theme);
 
         if (parameters == null) {
             parameters = new Bundle();
@@ -533,7 +533,7 @@ public class WebDialog extends Dialog {
         private Context context;
         private String applicationId;
         private String action;
-        private int theme = DEFAULT_THEME;
+        private int theme;
         private OnCompleteListener listener;
         private Bundle parameters;
         private AccessToken accessToken;


### PR DESCRIPTION
Always pick up a WebDialog theme set as meta-data in manifest, not only during login process.

Otherwise, for example, friend invite dialog will look like the following in fullscreen mode:

![screenshot_2015-10-29-21-02-49](https://cloud.githubusercontent.com/assets/1169233/10827536/a25328c4-7e80-11e5-9bca-17819f6d5f9f.png)
