### PR TITLE
data race for AppEventsLogger.stateMap fixed

### DIFF
--- a/facebook/src/main/java/com/facebook/appevents/AppEventsLogger.java
+++ b/facebook/src/main/java/com/facebook/appevents/AppEventsLogger.java
@@ -1599,8 +1599,6 @@ public class AppEventsLogger {
     static class PersistedEvents {
         static final String PERSISTED_EVENTS_FILENAME = "AppEventsLogger.persistedevents";
 
-        private static Object staticLock = new Object();
-
         private Context context;
         private HashMap<AccessTokenAppIdPair, List<AppEvent>> persistedEvents =
                 new HashMap<AccessTokenAppIdPair, List<AppEvent>>();


### PR DESCRIPTION
fix for relatively rare crashes like this:
com.facebook.AppEventsLogger(  706): Caught unexpected exception while flushing: java.lang.NullPointerException
java.lang.NullPointerException
  at java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:891)
  at com.facebook.internal.Utility.queryAppSettings(Utility.java:364)
  at com.facebook.AppEventsLogger$3.run(AppEventsLogger.java:623)
  at java.util.Timer$TimerImpl.run(Timer.java:284)

It happens because static methods of AppEventsLogger and AppEventsLogger.PersistedEvents use different objects with same name for synchronization.