### PR TITLE
Remove multiDexEnabled flag

### DIFF
--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -39,7 +39,6 @@ android {
     defaultConfig {
         minSdkVersion Integer.parseInt(project.ANDROID_BUILD_MIN_SDK_VERSION)
         targetSdkVersion Integer.parseInt(project.ANDROID_BUILD_TARGET_SDK_VERSION)
-        multiDexEnabled true
     }
 
     lintOptions {


### PR DESCRIPTION
Running `gradle dependencies` on my Android project I see the following result

```
[…]
+--- com.facebook.android:facebook-android-sdk:4.9.0
|    +--- com.parse.bolts:bolts-applinks:1.3.0
|    |    \--- com.parse.bolts:bolts-tasks:1.3.0
|    +--- com.android.support:multidex:1.0.1
|    +--- com.parse.bolts:bolts-tasks:1.3.0
|    +--- com.android.support:support-v4:(23,24] -> 23.1.1
|    \--- com.android.support:cardview-v7:(23,24] -> 23.1.1
[…]
```

I don't need the transitive dependency `com.android.support:multidex:1.0.1`. By removing the `multiDexEnabled true` flag from the transitive dependency is removed as well.