### PR TITLE
Fix request parsing to handle any passed-in request parameters

### DIFF
--- a/facebook/src/main/java/com/facebook/GraphRequest.java
+++ b/facebook/src/main/java/com/facebook/GraphRequest.java
@@ -1442,7 +1442,7 @@ public class GraphRequest {
     }
 
     private String appendParametersToBaseUrl(String baseUrl) {
-        Uri.Builder uriBuilder = new Uri.Builder().encodedPath(baseUrl);
+        Uri.Builder uriBuilder = new Uri.parse(baseUrl).buildUpon();
 
         Set<String> keys = this.parameters.keySet();
         for (String key : keys) {


### PR DESCRIPTION
On iOS, this works:
GraphRequest("/me?fields=id")

On Android, it does not, and the resulting URL looks like:
"/me?fields=id?access_token=X&other=params&included=here" (notice the two "?" chars)

This causes a very strange problem when react-native-fbsdk assumes they perform identically, as seen here:
https://github.com/facebook/react-native-fbsdk/issues/105

This should fix the issue and retain feature parity between iOS and Android.