### PR TITLE
Fix request parsing to handle any passed-in request parameters

### DIFF
--- a/facebook/src/main/java/com/facebook/GraphRequest.java
+++ b/facebook/src/main/java/com/facebook/GraphRequest.java
@@ -1471,14 +1471,17 @@ public class GraphRequest {
         return uriBuilder.toString();
     }
 
-    final String getUrlForBatchedRequest() {
+    final String getRelativeUrlForBatchedRequest() {
         if (overriddenURL != null) {
             throw new FacebookException("Can't override URL for a batch request");
         }
 
         String baseUrl = String.format("%s/%s", ServerProtocol.getGraphUrlBase(), getGraphPathWithVersion());
         addCommonParameters();
-        return appendParametersToBaseUrl(baseUrl);
+        String fullUrl = appendParametersToBaseUrl(baseUrl);
+        Uri uri = Uri.parse(fullUrl);
+        String relativeUrl = String.format("%s?%s", uri.getPath(), uri.getQuery());
+        return relativeUrl;
     }
 
     final String getUrlForSingleRequest() {
@@ -1542,7 +1545,7 @@ public class GraphRequest {
             batchEntry.put(BATCH_ENTRY_DEPENDS_ON_PARAM, this.batchEntryDependsOn);
         }
 
-        String relativeURL = getUrlForBatchedRequest();
+        String relativeURL = getRelativeUrlForBatchedRequest();
         batchEntry.put(BATCH_RELATIVE_URL_PARAM, relativeURL);
         batchEntry.put(BATCH_METHOD_PARAM, httpMethod);
         if (this.accessToken != null) {

--- a/facebook/src/main/java/com/facebook/GraphRequest.java
+++ b/facebook/src/main/java/com/facebook/GraphRequest.java
@@ -1442,7 +1442,7 @@ public class GraphRequest {
     }
 
     private String appendParametersToBaseUrl(String baseUrl) {
-        Uri.Builder uriBuilder = new Uri.Builder().encodedPath(baseUrl);
+        Uri.Builder uriBuilder = Uri.parse(baseUrl).buildUpon();
 
         Set<String> keys = this.parameters.keySet();
         for (String key : keys) {

--- a/facebook/src/main/java/com/facebook/GraphRequest.java
+++ b/facebook/src/main/java/com/facebook/GraphRequest.java
@@ -1476,7 +1476,7 @@ public class GraphRequest {
             throw new FacebookException("Can't override URL for a batch request");
         }
 
-        String baseUrl = getGraphPathWithVersion();
+        String baseUrl = String.format("%s/%s", ServerProtocol.getGraphUrlBase(), getGraphPathWithVersion());
         addCommonParameters();
         return appendParametersToBaseUrl(baseUrl);
     }


### PR DESCRIPTION
On iOS, this works:
GraphRequest("/me?fields=id")

On Android, it does not, and the resulting URL looks like:
"/me?fields=id?access_token=X&other=params&included=here" (notice the two "?" chars)

This causes a very strange problem when react-native-fbsdk assumes they perform identically, as seen here:
facebook/react-native-fbsdk#105

This should fix the issue and bring feature parity between iOS and Android.