### PR TITLE
Prevent the app from crash if a DeadObjectException happens in the ContentProvider

### DIFF
--- a/facebook/src/main/java/com/facebook/internal/NativeProtocol.java
+++ b/facebook/src/main/java/com/facebook/internal/NativeProtocol.java
@@ -876,7 +876,16 @@ public final class NativeProtocol {
             // logcat saying that the provider was not found.
             PackageManager pm = FacebookSdk.getApplicationContext().getPackageManager();
             String contentProviderName = appInfo.getPackage() + PLATFORM_PROVIDER;
-            ProviderInfo pInfo = pm.resolveContentProvider(contentProviderName, 0);
+            ProviderInfo pInfo = null;
+            try {
+                pInfo = pm.resolveContentProvider(contentProviderName, 0);
+            } catch (RuntimeException e) {
+                // Accessing a dead provider will cause an DeadObjectException in the
+                // package manager. It will be thrown as a Runtime Exception.
+                // This will cause a incorrect indication of if the FB app installed but
+                // it is better then crashing.
+                Log.e(TAG, "Failed to query content resolver.", e);
+            }
             if (pInfo != null) {
                 try {
                     c = contentResolver.query(uri, projection, null, null, null);


### PR DESCRIPTION
Hello,

We're having several crashes from DeadObjectExceptions while accessing the ContentProvider. This code should prevent it to crash the entire app, following the same politic than in line 892.

The stacktrace of the crash is:

> java.lang.RuntimeException: Package manager has died
	at android.app.ApplicationPackageManager.resolveContentProviderAsUser(ApplicationPackageManager.java:721)
	at android.app.ApplicationPackageManager.resolveContentProvider(ApplicationPackageManager.java:712)
	at com.facebook.internal.NativeProtocol.fetchAllAvailableProtocolVersionsForAppInfo(SourceFile:786)
	at com.facebook.internal.NativeProtocol.access$000(SourceFile:49)
	at com.facebook.internal.NativeProtocol$NativeAppInfo.fetchAvailableVersions(SourceFile:281)
	at com.facebook.internal.NativeProtocol$NativeAppInfo.access$600(SourceFile:226)
	at com.facebook.internal.NativeProtocol$1.run(SourceFile:761)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
	at java.lang.Thread.run(Thread.java:818)
Caused by: android.os.DeadObjectException
	at android.os.BinderProxy.transactNative(Native Method)
	at android.os.BinderProxy.transact(Binder.java:511)
	at android.content.pm.IPackageManager$Stub$Proxy.resolveContentProvider(IPackageManager.java:3457)
	at android.app.ApplicationPackageManager.resolveContentProviderAsUser(ApplicationPackageManager.java:719)
	... 9 more

If you need anything else, please don't hesitate to write me.

Thanks for your time.

I've already signed the CLA.