### PR TITLE
Added progress bar visibility setting

### DIFF
--- a/facebook/src/main/java/com/facebook/FacebookSdk.java
+++ b/facebook/src/main/java/com/facebook/FacebookSdk.java
@@ -79,6 +79,7 @@ public final class FacebookSdk {
     private static final int DEFAULT_KEEP_ALIVE = 1;
     private static int callbackRequestCodeOffset = 0xface;
     private static final Object LOCK = new Object();
+    private static boolean isShowingProgressBar = true;
 
     private static final int MAX_REQUEST_CODE_RANGE = 100;
 
@@ -367,6 +368,23 @@ public final class FacebookSdk {
      */
     public static void setLegacyTokenUpgradeSupported(boolean supported) {
         isLegacyTokenUpgradeSupported = supported;
+    }
+
+    /**
+     * Setter showing the progress bar at login attempt, so it could be overridden with other progress bar.
+     * @param isShowingProgressBar True if upgrade should be supported.
+     */
+    public static void setIsShowingProgressBar(boolean isShowingProgressBar) {
+        FacebookSdk.isShowingProgressBar = isShowingProgressBar;
+    }
+
+    /**
+     * Returns if the progress bar should be shown in situations like waiting for login results.
+     *
+     * @return if the progress bar shoud be shown
+     */
+    public static boolean isShowingProgressBar() {
+        return isShowingProgressBar;
     }
 
     /**

--- a/facebook/src/main/java/com/facebook/login/LoginClient.java
+++ b/facebook/src/main/java/com/facebook/login/LoginClient.java
@@ -24,8 +24,6 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
-import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v4.app.Fragment;
@@ -33,17 +31,13 @@ import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
 
 import com.facebook.AccessToken;
-import com.facebook.GraphRequest;
-import com.facebook.GraphResponse;
-import com.facebook.appevents.AppEventsConstants;
 import com.facebook.FacebookException;
-import com.facebook.HttpMethod;
 import com.facebook.R;
+import com.facebook.appevents.AppEventsConstants;
 import com.facebook.internal.CallbackManagerImpl;
 import com.facebook.internal.Utility;
 import com.facebook.internal.Validate;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -51,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/facebook/src/main/java/com/facebook/login/LoginFragment.java
+++ b/facebook/src/main/java/com/facebook/login/LoginFragment.java
@@ -31,6 +31,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.facebook.FacebookSdk;
 import com.facebook.R;
 
 /**
@@ -101,8 +102,10 @@ public class LoginFragment extends Fragment {
                 new LoginClient.BackgroundProcessingListener() {
                     @Override
                     public void onBackgroundProcessingStarted() {
-                        view.findViewById(R.id.com_facebook_login_activity_progress_bar)
-                                .setVisibility(View.VISIBLE);
+                        if(FacebookSdk.isShowingProgressBar()) {
+                            view.findViewById(R.id.com_facebook_login_activity_progress_bar)
+                                    .setVisibility(View.VISIBLE);
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
Hello,

I stumbled upon the problem, that many developer wants to hide or change the progress bar that is shown upon logging in. Its a gray not very nice animation, that is strictly only shows as the facebook login is going on, and if the app still has some waiting after the fb token arrived it is even not working as it is supposed. (ex. the app wants to call its own api at login too)

Until Android M the solution was, to make the com.facebook.FacebookActivity theme NoDisplay, but it crashes over Android M. [stackoverflow](https://stackoverflow.com/questions/30179373/android-facebook-android-sdk4-0-0-how-can-i-remove-the-login-progress-bar)

[Reason of crash](https://plus.google.com/+DianneHackborn/posts/LjnRzJKWPGW)

I put a static field in FacebookSdk class, with a getter and setter, which LoginFragment uses. It makes LoginFrament dependent on FacebookSdk.

My other solution would be FacebookSdk.initilaize get it as a parameter, it sets it in Utility and LoginClient or LoginFragment could access it, but I think the  first solution is better.

Please comment your opinion about the issue and the resolvment, if its ok. There may have been a better solution but I dont have a deep insight yet.
