### PR TITLE
Fix: Focus support for WebDialogs (Android TV)

### DIFF
--- a/facebook/src/main/java/com/facebook/internal/WebDialog.java
+++ b/facebook/src/main/java/com/facebook/internal/WebDialog.java
@@ -577,6 +577,24 @@ public class WebDialog extends Dialog {
             webView.setVisibility(View.VISIBLE);
             crossImageView.setVisibility(View.VISIBLE);
             isPageFinished = true;
+
+            String setFocusJS =
+                    "(function() {"+
+                            "  var items = Array.prototype.slice.call(document.getElementsByTagName('textarea'))."+
+                            "    concat(Array.prototype.slice.call(document.getElementsByTagName('input')))."+
+                            "    concat(Array.prototype.slice.call(document.getElementsByTagName('button')));"+
+                            "  for(var i = 0, c = items.length; i < c; i++) {"+
+                            "    var item = items[i];"+
+                            "    var type = item.tagName.toLowerCase();"+
+                            "    var att = item.getAttribute('type');"+
+                            "    if((att === 'text') || (att === 'email') || (att === 'submit') || (type === 'textarea') || (type === 'button')) {"+
+                            "      item.focus();"+
+                            "      break;"+
+                            "    }"+
+                            "  }"+
+                            "})();";
+
+            view.loadUrl("javascript:" + setFocusJS);
         }
     }
 


### PR DESCRIPTION
On Android TV users cannot interact with web dialogs due no touch
support. With gamepad, users can only scroll with the view.
Following commit injects Javascript function which finds most relevant
html element and sets focus to it. Then, users can use gamepad for
navigating in the dialog.
This fix works for login, sharing and app requests. Not working for app
invites.
Tested with Facebook SDK for Unity.