### PR TITLE
[SDK] Add ripple effect to Facebook SDK buttons

### DIFF
--- a/facebook/src/main/res/color-v21/com_facebook_button_background_color.xml
+++ b/facebook/src/main/res/color-v21/com_facebook_button_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,13 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:color="@color/com_facebook_button_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color-v21/com_facebook_button_like_background_color.xml
+++ b/facebook/src/main/res/color-v21/com_facebook_button_like_background_color.xml
@@ -13,18 +13,13 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:color="@color/com_facebook_button_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color-v21/com_facebook_button_login_background_color.xml
+++ b/facebook/src/main/res/color-v21/com_facebook_button_login_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,13 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:color="@color/com_facebook_button_login_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color-v21/com_facebook_button_login_silver_background_color.xml
+++ b/facebook/src/main/res/color-v21/com_facebook_button_login_silver_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,13 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:color="@color/com_facebook_button_login_silver_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color-v21/com_facebook_button_send_background_color.xml
+++ b/facebook/src/main/res/color-v21/com_facebook_button_send_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,13 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:color="@color/com_facebook_button_send_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_background_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,16 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused_disabled" />
+    <item android:state_enabled="false" android:state_focused="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused" />
+    <item android:state_pressed="true" android:color="@color/com_facebook_button_background_color_pressed" />
+    <item android:color="@color/com_facebook_button_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_border_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_border_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,14 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused" />
+    <item android:state_focused="false" android:color="@android:color/transparent" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_like_background_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_like_background_color.xml
@@ -13,18 +13,17 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:color="@color/com_facebook_button_background_color_pressed" />
+    <item android:state_enabled="false" android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused_disabled" />
+    <item android:state_enabled="false" android:state_focused="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused" />
+    <item android:state_selected="true" android:color="@color/com_facebook_button_background_color_selected" />
+    <item android:color="@color/com_facebook_button_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_login_background_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_login_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,16 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused_disabled" />
+    <item android:state_enabled="false" android:state_focused="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused" />
+    <item android:state_pressed="true" android:color="@color/com_facebook_button_background_color_pressed" />
+    <item android:color="@color/com_facebook_button_login_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_login_silver_background_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_login_silver_background_color.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,14 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:state_pressed="true" android:color="@color/com_facebook_button_login_silver_background_color_pressed" />
+    <item android:color="@color/com_facebook_button_login_silver_background_color_default" />
+</selector>

--- a/facebook/src/main/res/color/com_facebook_button_send_background_color.xml
+++ b/facebook/src/main/res/color/com_facebook_button_send_background_color.xml
@@ -13,18 +13,16 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
-        </shape>
-    </item>
-</layer-list>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused_disabled" />
+    <item android:state_enabled="false" android:state_focused="false" android:color="@color/com_facebook_button_background_color_disabled" />
+    <item android:state_focused="true" android:color="@color/com_facebook_button_background_color_focused" />
+    <item android:state_pressed="true" android:color="@color/com_facebook_button_send_background_color_pressed" />
+    <item android:color="@color/com_facebook_button_send_background_color_default" />
+</selector>

--- a/facebook/src/main/res/drawable-v21/com_facebook_button_background.xml
+++ b/facebook/src/main/res/drawable-v21/com_facebook_button_background.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,18 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
     <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
+        <shape>
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
+            <solid android:color="@color/com_facebook_button_background_color" />
         </shape>
     </item>
-</layer-list>
+</ripple>

--- a/facebook/src/main/res/drawable-v21/com_facebook_button_like_background.xml
+++ b/facebook/src/main/res/drawable-v21/com_facebook_button_like_background.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,18 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
     <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
+        <shape>
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
+            <solid android:color="@color/com_facebook_button_like_background_color" />
         </shape>
     </item>
-</layer-list>
+</ripple>

--- a/facebook/src/main/res/drawable-v21/com_facebook_button_login_background.xml
+++ b/facebook/src/main/res/drawable-v21/com_facebook_button_login_background.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,18 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
     <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
+        <shape>
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
+            <solid android:color="@color/com_facebook_button_login_background_color" />
         </shape>
     </item>
-</layer-list>
+</ripple>

--- a/facebook/src/main/res/drawable-v21/com_facebook_button_login_silver_background.xml
+++ b/facebook/src/main/res/drawable-v21/com_facebook_button_login_silver_background.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,18 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
     <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
+        <shape>
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
+            <solid android:color="@color/com_facebook_button_login_silver_background_color" />
         </shape>
     </item>
-</layer-list>
+</ripple>

--- a/facebook/src/main/res/drawable-v21/com_facebook_button_send_background.xml
+++ b/facebook/src/main/res/drawable-v21/com_facebook_button_send_background.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
     Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
@@ -13,18 +12,18 @@
 
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
     COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?attr/colorControlHighlight">
     <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_default" />
-            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
+        <shape>
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
+            <solid android:color="@color/com_facebook_button_send_background_color" />
         </shape>
     </item>
-</layer-list>
+</ripple>

--- a/facebook/src/main/res/drawable/com_facebook_button_like_background.xml
+++ b/facebook/src/main/res/drawable/com_facebook_button_like_background.xml
@@ -19,43 +19,11 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_pressed" />
-        </shape>
-    </item>
-    <item android:state_enabled="false"
-        android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused_disabled" />
-        </shape>
-    </item>
-    <item android:state_enabled="false"
-        android:state_focused="false">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_disabled" />
-        </shape>
-    </item>
-    <item android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused" />
-        </shape>
-    </item>
-    <item android:state_selected="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_selected" />
-        </shape>
-    </item>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color" />
+            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
+            <solid android:color="@color/com_facebook_button_like_background_color" />
         </shape>
     </item>
-</selector>
+</layer-list>

--- a/facebook/src/main/res/drawable/com_facebook_button_login_background.xml
+++ b/facebook/src/main/res/drawable/com_facebook_button_login_background.xml
@@ -19,40 +19,12 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused_disabled" />
-        </shape>
-    </item>
-    <item android:state_enabled="false" android:state_focused="false">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_disabled" />
-        </shape>
-    </item>
-    <item android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused" />
-            <stroke
-                android:width="1dp"
-                android:color="@color/com_facebook_button_border_color_focused"
-                >
-            </stroke>
-        </shape>
-    </item>
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_pressed" />
-        </shape>
-    </item>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
             <corners android:radius="@dimen/com_facebook_button_login_corner_radius" />
             <solid android:color="@color/com_facebook_button_login_background_color" />
+            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
         </shape>
     </item>
-</selector>
+</layer-list>

--- a/facebook/src/main/res/drawable/com_facebook_button_login_silver_background.xml
+++ b/facebook/src/main/res/drawable/com_facebook_button_login_silver_background.xml
@@ -19,23 +19,11 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_disabled" />
-        </shape>
-    </item>
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_login_silver_background_color_pressed" />
-        </shape>
-    </item>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
             <corners android:radius="@dimen/com_facebook_button_corner_radius" />
             <solid android:color="@color/com_facebook_button_login_silver_background_color" />
         </shape>
     </item>
-</selector>
+</layer-list>

--- a/facebook/src/main/res/drawable/com_facebook_button_send_background.xml
+++ b/facebook/src/main/res/drawable/com_facebook_button_send_background.xml
@@ -18,42 +18,12 @@
     IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
-
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false"
-        android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused_disabled" />
-        </shape>
-    </item>
-    <item android:state_enabled="false"
-        android:state_focused="false">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_disabled" />
-        </shape>
-    </item>
-    <item android:state_focused="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
-            <solid android:color="@color/com_facebook_button_background_color_focused" />
-            <stroke
-                android:width="1dp"
-                android:color="@color/com_facebook_button_border_color_focused" >
-            </stroke>
-        </shape>
-    </item>
-    <item android:state_pressed="true">
-        <shape android:shape="rectangle">
-            <corners android:radius="2dp" />
-            <solid android:color="@color/com_facebook_button_send_background_color_pressed" />
-        </shape>
-    </item>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <corners android:radius="2dp" />
+            <corners android:radius="@dimen/com_facebook_button_corner_radius" />
             <solid android:color="@color/com_facebook_button_send_background_color" />
+            <stroke android:width="1dp" android:color="@color/com_facebook_button_border_color" />
         </shape>
     </item>
-</selector>
+</layer-list>

--- a/facebook/src/main/res/values/styles.xml
+++ b/facebook/src/main/res/values/styles.xml
@@ -64,16 +64,16 @@
         <item name="android:shadowColor">#40000000</item>
     </style>
 
-    <color name="com_facebook_button_background_color">#415dae</color>
+    <color name="com_facebook_button_background_color_default">#415dae</color>
     <color name="com_facebook_button_background_color_focused">#FFFFFe</color>
     <color name="com_facebook_button_background_color_focused_disabled">#84878c</color>
     <color name="com_facebook_button_background_color_selected">#7c8fc8</color>
     <color name="com_facebook_button_background_color_disabled">#bdc1c9</color>
     <color name="com_facebook_button_background_color_pressed">#2f477a</color>
-    <color name="com_facebook_button_login_silver_background_color">#f4f6f8</color>
-    <color name="com_facebook_button_login_background_color">#4267b2</color>
+    <color name="com_facebook_button_login_silver_background_color_default">#f4f6f8</color>
+    <color name="com_facebook_button_login_background_color_default">#4267b2</color>
     <color name="com_facebook_button_login_silver_background_color_pressed">#e9eaf0</color>
-    <color name="com_facebook_button_send_background_color">@color/com_facebook_messenger_blue</color>
+    <color name="com_facebook_button_send_background_color_default">@color/com_facebook_messenger_blue</color>
     <color name="com_facebook_button_send_background_color_pressed">#006fff</color>
 
     <color name="com_facebook_button_border_color_focused">#dedee6</color>


### PR DESCRIPTION
  - Add ripple effect to Facebook SDK buttons if app is running on Android API 21 (i.e. Marshmallow) or later.
  - The ripple color will be extracted from`colorControlHighlight`, which should be defined at the app `values-v21/style.xml`.