### PR TITLE
Convert int to string to remove wrong argument warning

### DIFF
--- a/samples/Scrumptious/src/com/example/scrumptious/SelectionFragment.java
+++ b/samples/Scrumptious/src/com/example/scrumptious/SelectionFragment.java
@@ -749,7 +749,7 @@ public class SelectionFragment extends Fragment {
                             selectedUsers.get(1).optString("name"));
                 } else if (selectedUsers.size() > 2) {
                     text = String.format(getResources().getString(R.string.multiple_users_selected),
-                            selectedUsers.get(0).optString("name"), (selectedUsers.size() - 1));
+                            selectedUsers.get(0).optString("name"), String.valueOf(selectedUsers.size() - 1));
                 }
             }
             if (text == null) {


### PR DESCRIPTION
`R.string.multiple_users_selected` is expecting both arguments to be a string so fix the warning by converting int to string in the Scrumptious example.