### PR TITLE
Security issue: actually validate that the package name matches the current app

### DIFF
--- a/facebook/src/main/java/com/facebook/internal/Validate.java
+++ b/facebook/src/main/java/com/facebook/internal/Validate.java
@@ -260,7 +260,8 @@ public final class Validate {
         if (infos != null) {
             for (ResolveInfo info : infos) {
                 ActivityInfo activityInfo = info.activityInfo;
-                if (activityInfo.name.equals(CustomTabActivity.class.getName())) {
+                if (activityInfo.name.equals(CustomTabActivity.class.getName())
+                    && activityInfo.packageName.equals(context.getPackageName())) {
                     hasActivity = true;
                 } else {
                     // another application is listening for this url scheme, don't open


### PR DESCRIPTION
The previous check `activityInfo.name.equals(CustomTabActivity.class.getName()` was just verifying that the advertising app has a CustomTabActivity, not that _this_ app has a CustomTabActivity.  This means a malicious app could advertise their own CustomTabActivity and collect facebook credentials for their own uses.