### PR TITLE
Fix NPE in ActivityLifecycleTracker

### DIFF
--- a/facebook/src/main/java/com/facebook/appevents/internal/ActivityLifecycleTracker.java
+++ b/facebook/src/main/java/com/facebook/appevents/internal/ActivityLifecycleTracker.java
@@ -274,10 +274,11 @@ public class ActivityLifecycleTracker {
     }
 
     private static void cancelCurrentTask() {
-        if (currentFuture != null) {
-            currentFuture.cancel(false);
-        }
-
+        ScheduledFuture future = currentFuture;
         currentFuture = null;
+
+        if (future != null) {
+            future.cancel(false);
+        }
     }
 }


### PR DESCRIPTION
Fix for possible race condition in `ActivityLifecycleTracker` that may leads to `NullPointerException` in rare cases on fast consequential calls `onActivityPaused` → `onActivityResumed` (usual scenario of another activity start?).

```
Caused by java.lang.NullPointerException: Attempt to invoke interface method 'boolean java.util.concurrent.ScheduledFuture.cancel(boolean)' on a null object reference
       at com.facebook.appevents.internal.ActivityLifecycleTracker.cancelCurrentTask(ActivityLifecycleTracker.java:278)
       at com.facebook.appevents.internal.ActivityLifecycleTracker.onActivityResumed(ActivityLifecycleTracker.java:152)
       at com.facebook.appevents.internal.ActivityLifecycleTracker$1.onActivityResumed(ActivityLifecycleTracker.java:82)
       at android.app.Application.dispatchActivityResumed(Application.java:232)
       at android.app.Activity.onResume(Activity.java:1284)
```