### PR TITLE
Fixed version number in README (4.27 -> 4.27.0)

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -68,25 +68,25 @@ include the appropriate dependency (or dependencies) listed below in your `app/b
     
     dependencies {
         // Facebook Core only (Analytics)
-        compile 'com.facebook.android:facebook-core:4.27'
+        compile 'com.facebook.android:facebook-core:4.27.0'
         
         // Facebook Login only
-        compile 'com.facebook.android:facebook-login:4.27'
+        compile 'com.facebook.android:facebook-login:4.27.0'
         
         // Facebook Share only
-        compile 'com.facebook.android:facebook-share:4.27'
+        compile 'com.facebook.android:facebook-share:4.27.0'
         
         // Facebook Places only
-        compile 'com.facebook.android:facebook-places:4.27'
+        compile 'com.facebook.android:facebook-places:4.27.0'
         
         // Facbeook Messenger only
-        compile 'com.facebook.android:facebook-messenger:4.27'
+        compile 'com.facebook.android:facebook-messenger:4.27.0'
         
         // Facebook App Links only
-        compile 'com.facebook.android:facebook-applinks:4.27'
+        compile 'com.facebook.android:facebook-applinks:4.27.0'
         
         // Facebook Android SDK (everything)
-        compile 'com.facebook.android:facebook-android-sdk:4.27'
+        compile 'com.facebook.android:facebook-android-sdk:4.27.0'
     }
 
 You may also need to add the following to your project/build.gradle file.


### PR DESCRIPTION
The following error occurred when I tried to install Facebook SDK 4.27.0 in my app.

```
Error:(237, 13) Failed to resolve: com.facebook.android:facebook-core:4.27
```

The cause of this error is mistaken version number in README. So I fixed this from `4.27` to `4.27.0`.