### PR TITLE
replace compile with implementation

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -68,25 +68,25 @@ include the appropriate dependency (or dependencies) listed below in your `app/b
     
     dependencies {
         // Facebook Core only (Analytics)
-        compile 'com.facebook.android:facebook-core:4.28.0'
+        implementation 'com.facebook.android:facebook-core:4.28.0'
         
         // Facebook Login only
-        compile 'com.facebook.android:facebook-login:4.28.0'
+        implementation 'com.facebook.android:facebook-login:4.28.0'
         
         // Facebook Share only
-        compile 'com.facebook.android:facebook-share:4.28.0'
+        implementation 'com.facebook.android:facebook-share:4.28.0'
         
         // Facebook Places only
-        compile 'com.facebook.android:facebook-places:4.28.0'
+        implementation 'com.facebook.android:facebook-places:4.28.0'
         
         // Facbeook Messenger only
-        compile 'com.facebook.android:facebook-messenger:4.28.0'
+        implementation 'com.facebook.android:facebook-messenger:4.28.0'
         
         // Facebook App Links only
-        compile 'com.facebook.android:facebook-applinks:4.28.0'
+        implementation 'com.facebook.android:facebook-applinks:4.28.0'
         
         // Facebook Android SDK (everything)
-        compile 'com.facebook.android:facebook-android-sdk:4.28.0'
+        implementation 'com.facebook.android:facebook-android-sdk:4.28.0'
     }
 
 You may also need to add the following to your project/build.gradle file.


### PR DESCRIPTION
After the Gradle 3.0, compile is now deprecated and no longer used.
It should be replaced with implementation 
cf: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [ ] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [ ] submit against our `:dev` branch, not `master`.
- [ ] describe the change (for example, what happens before the change, and after the change)
