### PR TITLE
Fixed WebDialog missing accessToken

### DIFF
--- a/facebook-common/src/main/java/com/facebook/internal/WebDialog.java
+++ b/facebook-common/src/main/java/com/facebook/internal/WebDialog.java
@@ -701,6 +701,8 @@ public class WebDialog extends Dialog {
                     throw new FacebookException("Attempted to create a builder without a valid" +
                             " access token or a valid default Application ID.");
                 }
+            } else {
+              accessToken = AccessToken.getCurrentAccessToken();
             }
 
             finishInit(context, action, parameters);


### PR DESCRIPTION
Sets accessToken in WebDialog Builder if it’s Active to fix missing auth-token bug in WebDialogs with would require re-login.

Before Change:

WebDialogs would be redirected to Login Form because of the missing the auth-token. This doesn't happen if the user logged in using Web Login in that session. If the user didn't log in in that session or used a native login (with native FB app) then this bug would manifest.

After Change:

WebDialogs work as expected, no redirect to login form.