### PR TITLE
setCurrentAccessToken changed.

### DIFF
--- a/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
+++ b/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
@@ -117,6 +117,8 @@ final public class AccessTokenManager {
 
     private void setCurrentAccessToken(AccessToken currentAccessToken, boolean saveToCache) {
         AccessToken oldAccessToken = this.currentAccessToken;
+        if(currentAccessToken != null && currentAccessToken.isExpired())
+            currentAccessToken = null;
         this.currentAccessToken = currentAccessToken;
         tokenRefreshInProgress.set(false);
         this.lastAttemptedTokenExtendDate = new Date(0);


### PR DESCRIPTION
check argument token expiration.

I think it's better to checking argument token before set.
It will be resolve some token expired situation maybe.

I updated similar logic on iOS repository.


Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
