### PR TITLE
Fix bug:sdkInitialize method set availableVersions not null,but empty then facebook app cannot be launched.

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/NativeProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/NativeProtocol.java
@@ -276,14 +276,14 @@ public final class NativeProtocol {
         private TreeSet<Integer> availableVersions;
 
         public TreeSet<Integer> getAvailableVersions() {
-            if (availableVersions == null) {
+            if (availableVersions == null || availableVersions.size() == 0) {
                 fetchAvailableVersions(false);
             }
             return availableVersions;
         }
 
         private synchronized void fetchAvailableVersions(boolean force) {
-            if (force || availableVersions == null) {
+            if (force || availableVersions == null || availableVersions.size() == 0) {
                 availableVersions = fetchAllAvailableProtocolVersionsForAppInfo(this);
             }
         }


### PR DESCRIPTION
When facebook app is not alive, sdk cannot fetch ProtocolVersions from faceboook app using ContentProvider. (Because many Chinese smart phone disallow application started by other app.)

So when launching sharing app, then lanunch the facebook app, shaing app cannot start facebook app when sharing at the first time.

This is becasue FacebookSdk.sdkInitialize method makes availableVersions not null, but empty. So I add this to fix this bug.



