### PR TITLE
Remove android:supportsRtl="true" from facebook-common

### DIFF
--- a/facebook-common/src/main/AndroidManifest.xml
+++ b/facebook-common/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.facebook.common">
 
-    <application android:supportsRtl="true">
+    <application>
 
         <activity
             android:name="com.facebook.FacebookActivity"


### PR DESCRIPTION
Each app that depends on this library should choose for themselves if they support right-to-left or not. I don't want a library to set this automatically without me knowing it by checking the merged manifest.
