### PR TITLE
Silently catch exceptions from invalid enum values

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/codeless/internal/EventBinding.java
+++ b/facebook-core/src/main/java/com/facebook/appevents/codeless/internal/EventBinding.java
@@ -24,6 +24,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.lang.IllegalArgumentException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -73,12 +74,15 @@ public class EventBinding {
         } catch (JSONException e) {
             // Ignore
         }
+        } catch (IllegalArgumentException e) {
+            // Ignore
+        }
 
         return eventBindings;
     }
 
     public static EventBinding getInstanceFromJson(final JSONObject mapping)
-            throws JSONException {
+            throws JSONException, IllegalArgumentException {
         String eventName = mapping.getString("event_name");
         MappingMethod method = MappingMethod.valueOf(mapping.getString("method").toUpperCase(Locale.ENGLISH));
         ActionType type = ActionType.valueOf(mapping.getString("event_type").toUpperCase(Locale.ENGLISH));

--- a/facebook-core/src/main/java/com/facebook/appevents/codeless/internal/EventBinding.java
+++ b/facebook-core/src/main/java/com/facebook/appevents/codeless/internal/EventBinding.java
@@ -73,7 +73,6 @@ public class EventBinding {
             }
         } catch (JSONException e) {
             // Ignore
-        }
         } catch (IllegalArgumentException e) {
             // Ignore
         }


### PR DESCRIPTION
Your current SDK crashes all the time for real users:
```
java.lang.IllegalArgumentException: 
   at java.lang.Enum.valueOf (Enum.java:257)
   at com.facebook.appevents.codeless.internal.EventBinding$MappingMethod.valueOf (EventBinding.java:154)
 at com.facebook.appevents.codeless.internal.EventBinding.getInstanceFromJson (EventBinding.java:82)
  at com.facebook.appevents.codeless.internal.EventBinding.parseArray (EventBinding.java:69)
  at com.facebook.appevents.codeless.CodelessMatcher$ViewMatcher.run (CodelessMatcher.java:224)
  at android.os.Handler.handleCallback (Handler.java:789)
  at android.os.Handler.dispatchMessage (Handler.java:98)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:6944)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:327)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1374)
```

There already is a bug report for this but it has not been worked on yet because it is stuck in "need more info" state:
https://developers.facebook.com/support/bugs/278547559523105/

Looks like this comes from invalid/unexpected values delivered by your codeless configuration JSON data.

What this change does
--
This change fixes the uncaught exceptions by catching them to avoid the resulting crashes. Imho this should be done anyway for incoming data processing and should have been done from the start of this feature.

What this change doesn't do
--
The unexpected values in the configuration data have to be handled somehow of course but this is out of the scope of this fix.

Misc
--
To whom it may concern: your pull request template seems to be out of date. It tells me to issue my pull request against your `:dev` branch but there is no such branch.