### PR TITLE
Removes warning about strings not having default translation

### DIFF
--- a/facebook-common/src/main/res/values-fr-rCA/strings.xml
+++ b/facebook-common/src/main/res/values-fr-rCA/strings.xml
@@ -12,7 +12,6 @@
     <string name="com_facebook_loginview_log_in_button_continue" gender="unknown">Continuer avec Facebook</string>
     <string name="com_facebook_loginview_logged_in_as" gender="unknown">Connecté en tant que : %1$s</string>
     <string name="com_facebook_loginview_logged_in_using_facebook" gender="unknown">Connecté avec Facebook</string>
-    <string name="com_facebook_loginview_logged_in_using_facebook_f1gender" gender="female">Connectée avec Facebook</string>
     <string name="com_facebook_loginview_log_out_action" gender="unknown">Se déconnecter</string>
     <string name="com_facebook_loginview_cancel_action" gender="unknown">Annuler</string>
     <string name="com_facebook_loading" gender="unknown">Chargement...</string>

--- a/facebook-login/src/main/res/values-fr-rCA/strings.xml
+++ b/facebook-login/src/main/res/values-fr-rCA/strings.xml
@@ -12,7 +12,6 @@
     <string name="com_facebook_loginview_log_in_button_continue" gender="unknown">Continuer avec Facebook</string>
     <string name="com_facebook_loginview_logged_in_as" gender="unknown">Connecté en tant que : %1$s</string>
     <string name="com_facebook_loginview_logged_in_using_facebook" gender="unknown">Connecté avec Facebook</string>
-    <string name="com_facebook_loginview_logged_in_using_facebook_f1gender" gender="female">Connectée avec Facebook</string>
     <string name="com_facebook_loginview_log_out_action" gender="unknown">Se déconnecter</string>
     <string name="com_facebook_loginview_cancel_action" gender="unknown">Annuler</string>
     <string name="com_facebook_loading" gender="unknown">Chargement...</string>


### PR DESCRIPTION
## What:
- removed unused strings translations for `com_facebook_loginview_logged_in_using_facebook_f1gender`

## Why:
 Android Studio keeps complaining about that string not having a default translation in the SDK. After looking at the source it seems the string is no longer used, so I removed its renaming translations.

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [X] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [C] submit against our `master`.
- [X] describe the change (for example, what happens before the change, and after the change)
