### PR TITLE
ViewIndexer leaked the calling activity by referencing it in a TimerTask

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/codeless/ViewIndexer.java
+++ b/facebook-core/src/main/java/com/facebook/appevents/codeless/ViewIndexer.java
@@ -80,16 +80,15 @@ public class ViewIndexer {
     }
 
     public void schedule() {
-        final Activity activity = activityReference.get();
-        if (null == activity) {
-            return;
-        }
-        final String activityName = activity.getClass().getSimpleName();
-
         final TimerTask indexingTask = new TimerTask() {
             @Override
             public void run() {
                 try {
+                    final Activity activity = activityReference.get();
+                    if (null == activity) {
+                        return;
+                    }
+                    final String activityName = activity.getClass().getSimpleName();
                     final View rootView =
                             activity.getWindow().getDecorView().getRootView();
 


### PR DESCRIPTION
Reference has been moved into TimerTask#run in order to not leak the calling Activity.

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
