### PR TITLE
Remove android:supportsRtl="true" from facebook-core

### DIFF
--- a/facebook-core/src/main/AndroidManifest.xml
+++ b/facebook-core/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.facebook.core">
 
-    <application android:supportsRtl="true">
+    <application>
 
         <!-- The initialization ContentProvider will call FacebookSdk.sdkInitialize automatically
          with the application context. This config is merged in with the host app's manifest,


### PR DESCRIPTION
Each app that depends on this library should choose for themselves if they support right-to-left or not. I don't want a library to set this automatically without me knowing it by checking the merged manifest.

Relates to #539 