### PR TITLE
Fix broken tests

### DIFF
--- a/facebook/src/test/java/com/facebook/FacebookPowerMockTestCase.java
+++ b/facebook/src/test/java/com/facebook/FacebookPowerMockTestCase.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 // ShadowLog is used to redirect the android.util.Log calls to System.out
 @SuppressLint("RunWithRobolectricTestRunner")
-@Config(shadows = {ShadowLog.class}, manifest = Config.NONE)
+@Config(shadows = {ShadowLog.class}, manifest = Config.NONE, sdk = 21)
 @RunWith(RobolectricTestRunner.class)
 @PowerMockIgnore({ "org.mockito.*", "org.robolectric.*", "androidx.*", "android.*", "org.json.*" })
 


### PR DESCRIPTION
Summary: Travis is broken for "java.lang.NoClassDefFoundError: Could not initialize class android.os.AsyncTask", that's an Android 4 issue and we enforce sdk 21 to fix that

Differential Revision: D15357372

