### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/facebook-core/proguard-rules.pro
+++ b/facebook-core/proguard-rules.pro
@@ -50,7 +50,10 @@
 
 -keep class com.facebook.core.Core
 
--keep public class com.android.vending.billing.IInAppBillingService {
-    public static com.android.vending.billing.IInAppBillingService asInterface(android.os.IBinder);
-    public android.os.Bundle getSkuDetails(int, java.lang.String, java.lang.String, android.os.Bundle);
+# keep class names and method names used by reflection by InAppPurchaseEventManager
+-keepnames public class com.android.vending.billing.IInAppBillingService {
+    public <methods>;
+}
+-keepnames public class com.android.vending.billing.IInAppBillingService$Stub {
+    public <methods>;
 }


### PR DESCRIPTION
When using minification of the Android app, the In-App Billing Service gets obfuscated, resulting in runtime internal crashes.
This patch keeps the affected method names used by reflective calls.

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [X] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [X] submit against our `master`.
- [X] describe the change (for example, what happens before the change, and after the change)
