### PR TITLE
KEYCODE_BACK is handled in more generic way

### DIFF
--- a/facebook-common/src/main/java/com/facebook/internal/WebDialog.java
+++ b/facebook-common/src/main/java/com/facebook/internal/WebDialog.java
@@ -291,12 +291,12 @@ public class WebDialog extends Dialog {
     }
 
     @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK) {
             cancel();
         }
 
-        return super.onKeyDown(keyCode, event);
+        return super.onKeyUp(keyCode, event);
     }
 
     @Override


### PR DESCRIPTION
BACK button should be handled in a `onKeyUp` handler for more generic behaviour.
More details: https://github.com/facebook/facebook-android-sdk/issues/607

