### PR TITLE
Change intent flag to update current alarm.

### DIFF
--- a/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
+++ b/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
@@ -167,7 +167,7 @@ final public class AccessTokenManager {
 
         Intent intent = new Intent(context, CurrentAccessTokenExpirationBroadcastReceiver.class);
         intent.setAction(ACTION_CURRENT_ACCESS_TOKEN_CHANGED);
-        PendingIntent alarmIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+        PendingIntent alarmIntent = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         try {
             alarmManager.set(


### PR DESCRIPTION
To avoid security crash on some Samsung devices.

- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Some Samsung devices throw fatal exception (java.lang.SecurityException: !@Too many alarms (500) registered from uid xxxxx) while setting token expiration broadcast alarm. Because previously created alarms can't cancel so alarms are duplicated.

But when after changing flag 0 to PendingIntent.FLAG_UPDATE_CURRENT, instead of creating a new alarm, the existing one is being updated.