### PR TITLE
Add resource prefix to prevent conflicts

### DIFF
--- a/facebook-common/build.gradle
+++ b/facebook-common/build.gradle
@@ -48,6 +48,7 @@ android {
         targetSdkVersion project.ext.targetSdk
         consumerProguardFiles 'proguard-rules.pro'
         vectorDrawables.useSupportLibrary = true
+        resourcePrefix "com_facebook_"
     }
 
     aaptOptions {

--- a/facebook-login/build.gradle
+++ b/facebook-login/build.gradle
@@ -44,6 +44,7 @@ android {
         targetSdkVersion project.ext.targetSdk
         consumerProguardFiles 'proguard-rules.pro'
         vectorDrawables.useSupportLibrary = true
+        resourcePrefix "com_facebook_"
     }
 
     buildTypes {

--- a/facebook-login/src/main/res/layout/com_facebook_tooltip_bubble.xml
+++ b/facebook-login/src/main/res/layout/com_facebook_tooltip_bubble.xml
@@ -49,7 +49,7 @@
           android:layout_toLeftOf="@id/com_facebook_button_xout"
           android:layout_alignParentLeft="true"
           android:padding="10dp"
-          style="@style/tooltip_bubble_text"
+          style="@style/com_facebook_tooltip_bubble_text"
           />
   </RelativeLayout>
   <ImageView

--- a/facebook-login/src/main/res/values/styles.xml
+++ b/facebook-login/src/main/res/values/styles.xml
@@ -20,7 +20,7 @@
 -->
 
 <resources>
-    <style name="tooltip_bubble_text">
+    <style name="com_facebook_tooltip_bubble_text">
         <item name="android:textColor">@android:color/white</item>
         <item name="android:gravity">left</item>
         <item name="android:textSize">12sp</item>

--- a/facebook-messenger/build.gradle
+++ b/facebook-messenger/build.gradle
@@ -42,6 +42,7 @@ android {
         targetSdkVersion project.ext.targetSdk
         consumerProguardFiles 'proguard-rules.pro'
         vectorDrawables.useSupportLibrary = true
+        resourcePrefix "messenger_"
     }
 
     aaptOptions {

--- a/facebook-share/build.gradle
+++ b/facebook-share/build.gradle
@@ -43,6 +43,7 @@ android {
         targetSdkVersion project.ext.targetSdk
         consumerProguardFiles 'proguard-rules.pro'
         vectorDrawables.useSupportLibrary = true
+        resourcePrefix "com_facebook_"
     }
 
     aaptOptions {


### PR DESCRIPTION
## Pull Request Details
#### Main purpose:
Resource prefix is important to prevent resource conflict with the hosting app.

Using `resourcePrefix` in Gradle help preventing this situation by making sure that all the resources in the module prefixed, otherwise you will get a warning.

Any developer adds a new resource to those modules he gets a message asking them to add a prefix to the resource.

#### Technical description:
* add `"com_facebook_"` prefix to **common** & **login** & **share** moduels
* add `"messenger_"` prefix to **messenger** moduel
* rename resouse and add prefix, `tooltip_bubble_text` -> `com_facebook_tooltip_bubble_text`
