### PR TITLE
Log fb_auto_applink in sdkInitialize

### DIFF
--- a/facebook-core/src/main/java/com/facebook/FacebookSdk.java
+++ b/facebook-core/src/main/java/com/facebook/FacebookSdk.java
@@ -319,6 +319,8 @@ public final class FacebookSdk {
         // Fetch available protocol versions from the apps on the device
         NativeProtocol.updateAllAvailableProtocolVersionsAsync();
 
+        UserSettingsManager.logIfAutoAppLinkEnabled();
+
         BoltsMeasurementEventListener.getInstance(FacebookSdk.applicationContext);
 
         cacheDir = new LockOnGetVariable<File>(

--- a/facebook-core/src/main/java/com/facebook/UserSettingsManager.java
+++ b/facebook-core/src/main/java/com/facebook/UserSettingsManager.java
@@ -113,7 +113,6 @@ final class UserSettingsManager {
         initializeCodelessSetupEnabledAsync();
         logWarnings();
         logIfSDKSettingsChanged();
-        logIfAutoAppLinkEnabled();
     }
 
     private static void initializeUserSetting(UserSetting... userSettings) {
@@ -310,7 +309,7 @@ final class UserSettingsManager {
         }
     }
 
-    private static void logIfAutoAppLinkEnabled() {
+    static void logIfAutoAppLinkEnabled() {
         try {
             final Context ctx = FacebookSdk.getApplicationContext();
             ApplicationInfo ai = ctx.getPackageManager().getApplicationInfo(


### PR DESCRIPTION
Summary:
fb_auto_applink event is logged when com.facebook.sdk.AutoAppLinkEnabled is set to be true and it respects AutoLog flag.
We also need to log this event when developers manually initialize FB SDK and thus we move the logging to sdkInitialize.

Differential Revision: D19502505

