### PR TITLE
Update travis to accept sdk 28 license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ android:
   components:
   - build-tools-26
   - build-tools-27.0.3
+  - build-tools-28.0.0
   - android-26
   - android-27
+  - android-28
   - extra
 licenses:
 - android-sdk-preview-license-.+
@@ -15,6 +17,7 @@ dist: trusty
 
 before_install:
 - yes | sdkmanager "platforms;android-27"
+- yes | sdkmanager "platforms;android-28"
 - chmod +x gradlew
 - chmod +x .travis/release.sh
 install:


### PR DESCRIPTION
Summary: Title, see build failure on github

Differential Revision: D19517120

