### PR TITLE
Asks developer to use their app id for sample apps

### DIFF
--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/MainActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/MainActivity.java
@@ -21,6 +21,7 @@
 package com.facebook.fbloginsample;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -35,10 +36,16 @@ public class MainActivity extends Activity {
     private static final int RESULT_POSTS_ACTIVITY = 2;
     private static final int RESULT_PERMISSIONS_ACTIVITY = 3;
 
+    private static final String DEFAULT_FB_APP_ID = "ENTER_YOUR_FB_APP_ID_HERE";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        if (getResources().getString(R.string.facebook_app_id).equals(DEFAULT_FB_APP_ID)) {
+            showAlertNoFacebookAppId();
+            return;
+        }
 
         // If MainActivity is reached without the user being logged in, redirect to the Login
         // Activity
@@ -131,5 +138,14 @@ public class MainActivity extends Activity {
             default:
                 super.onActivityResult(requestCode,resultCode, data);
         }
+    }
+
+    private void showAlertNoFacebookAppId() {
+        AlertDialog alert = new AlertDialog.Builder(MainActivity.this).create();
+        alert.setTitle("Use your facebook app id in strings.xml");
+        alert.setMessage("This sample app can not properly function without your app id. " +
+                "Use your facebook app id in strings.xml. Check out https://developers.facebook.com/docs/android/getting-started/ for more info. " +
+                "Restart the app after that");
+        alert.show();
     }
 }

--- a/samples/FBLoginSample/src/main/res/values/strings.xml
+++ b/samples/FBLoginSample/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">FB Login Sample</string>
-    <string name="facebook_app_id">117498238887011</string>
-    <string name="fb_login_protocol_scheme">fb117498238887011</string>
+    <string name="facebook_app_id">ENTER_YOUR_FB_APP_ID_HERE</string>
+    <string name="fb_login_protocol_scheme">fb{ENTER_YOUR_FB_APP_ID_HERE}</string> <!-- keep the fb prefix and remove braces-->
     <string name="posts_feed">Posts</string>
     <string name="logout">Logout</string>
     <string name="enter_text">Compose a post</string>
@@ -14,5 +14,4 @@
     <string name="no_fb_review">Permissions Granted without FB Review</string>
     <string name="fb_review">Permissions Requiring FB Review</string>
     <string name="no_email_perm">Email permission not granted</string>
-
 </resources>


### PR DESCRIPTION
Summary:
Title.
There are a few reasons:
1) We do not want developers to use app ids of sample apps for their real apps.
2) We want to understand how useful the sample apps are.

This requires the devs to follow the getting-started guide.

Bypasses alert if you change the string to anything else, but giving a non-valid appid will not make it work correctly.

Only doing it for FBLoginSample app for now. After we decide what other sample apps to keep we can do same thing there.

Differential Revision: D19539088

