### PR TITLE
Add graph_domain support to AccessToken

### DIFF
--- a/facebook-common/src/main/java/com/facebook/login/LoginManager.java
+++ b/facebook-common/src/main/java/com/facebook/login/LoginManager.java
@@ -794,6 +794,8 @@ public class LoginManager {
                                     result.getStringArrayList(NativeProtocol.EXTRA_PERMISSIONS);
                             final String signedRequest =
                                     result.getString(NativeProtocol.RESULT_ARGS_SIGNED_REQUEST);
+                            final String graphDomain =
+                                    result.getString(NativeProtocol.RESULT_ARGS_GRAPH_DOMAIN);
                             Date dataAccessExpirationTime = Utility.getBundleLongAsDate(
                                     result,
                                     NativeProtocol.EXTRA_DATA_ACCESS_EXPIRATION_TIME,
@@ -818,7 +820,8 @@ public class LoginManager {
                                         null,
                                         expires,
                                         null,
-                                        dataAccessExpirationTime);
+                                        dataAccessExpirationTime,
+                                        graphDomain);
                                 AccessToken.setCurrentAccessToken(accessToken);
 
                                 final Profile profile = getProfileFromBundle(result);

--- a/facebook-common/src/main/java/com/facebook/login/LoginMethodHandler.java
+++ b/facebook-common/src/main/java/com/facebook/login/LoginMethodHandler.java
@@ -134,6 +134,7 @@ abstract class LoginMethodHandler implements Parcelable {
         }
 
         String userId = bundle.getString(NativeProtocol.EXTRA_USER_ID);
+        String graphDomain = bundle.getString(NativeProtocol.RESULT_ARGS_GRAPH_DOMAIN);
         return new AccessToken(
                 token,
                 applicationId,
@@ -144,7 +145,8 @@ abstract class LoginMethodHandler implements Parcelable {
                 source,
                 expires,
                 new Date(),
-                dataAccessExpirationTime);
+                dataAccessExpirationTime,
+                graphDomain);
     }
 
     public static AccessToken createAccessTokenFromWebBundle(
@@ -182,6 +184,7 @@ abstract class LoginMethodHandler implements Parcelable {
             return null;
         }
 
+        String graphDomain = bundle.getString("graph_domain");
         String signed_request = bundle.getString("signed_request");
         String userId = getUserIDFromSignedRequest(signed_request);
 
@@ -195,7 +198,8 @@ abstract class LoginMethodHandler implements Parcelable {
                 source,
                 expires,
                 new Date(),
-                dataAccessExpirationTime);
+                dataAccessExpirationTime,
+                graphDomain);
     }
 
     static String getUserIDFromSignedRequest(

--- a/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
+++ b/facebook-core/src/main/java/com/facebook/AccessTokenManager.java
@@ -217,6 +217,7 @@ final public class AccessTokenManager {
     ) {
         Bundle parameters = new Bundle();
         parameters.putString("grant_type", "fb_extend_sso_token");
+        parameters.putString("client_id", accessToken.getApplicationId());
         return new GraphRequest(
                 accessToken,
                 TOKEN_EXTEND_GRAPH_PATH,
@@ -229,6 +230,7 @@ final public class AccessTokenManager {
         public String accessToken;
         public int expiresAt;
         public Long dataAccessExpirationTime;
+        public String graphDomain;
     }
 
     void refreshCurrentAccessToken(final AccessToken.AccessTokenRefreshCallback callback) {
@@ -318,6 +320,7 @@ final public class AccessTokenManager {
                         refreshResult.expiresAt = data.optInt("expires_at");
                         refreshResult.dataAccessExpirationTime =
                                 data.optLong("data_access_expiration_time");
+                        refreshResult.graphDomain = data.optString("graph_domain", null);
                     }
                 })
         );
@@ -363,7 +366,8 @@ final public class AccessTokenManager {
                             new Date(),
                             refreshResult.dataAccessExpirationTime != null
                                     ? new Date(refreshResult.dataAccessExpirationTime * 1000l)
-                                    : accessToken.getDataAccessExpirationTime()
+                                    : accessToken.getDataAccessExpirationTime(),
+                            refreshResult.graphDomain
                     );
                     getInstance().setCurrentAccessToken(newAccessToken);
                 } finally {

--- a/facebook-core/src/main/java/com/facebook/FacebookSdk.java
+++ b/facebook-core/src/main/java/com/facebook/FacebookSdk.java
@@ -79,6 +79,7 @@ public final class FacebookSdk {
     private static volatile String appClientToken;
     private static volatile Boolean codelessDebugLogEnabled;
     private static final String FACEBOOK_COM = "facebook.com";
+    private static final String FB_GG = "fb.gg";
     private static volatile String facebookDomain = FACEBOOK_COM;
     private static AtomicLong onProgressThreshold = new AtomicLong(65536);
     private static volatile boolean isDebugEnabled = BuildConfig.DEBUG;
@@ -563,12 +564,31 @@ public final class FacebookSdk {
 
     /**
      * Gets the base Facebook domain to use when making Web requests; in production code this will
-     * always be "facebook.com".
+     * normally be "facebook.com". However certain Access Tokens are meant to be used with other
+     * domains. Currently gaming -> fb.gg
+     *
+     * This checks the current Access Token (if any) and returns the correct domain to use.
      *
      * @return the Facebook domain
      */
     public static String getFacebookDomain() {
-        return facebookDomain;
+        AccessToken currentToken = AccessToken.getCurrentAccessToken();
+        String tokenGraphDomain = null;
+        String graphDomain;
+
+        if (currentToken != null) {
+            tokenGraphDomain = currentToken.getGraphDomain();
+        }
+
+        if (tokenGraphDomain == null) {
+            graphDomain = facebookDomain;
+        } else if (tokenGraphDomain.equals("gaming")) {
+            graphDomain = facebookDomain.replace(FACEBOOK_COM, FB_GG);
+        } else {
+            graphDomain = facebookDomain;
+        }
+
+        return graphDomain;
     }
 
     /**

--- a/facebook-core/src/main/java/com/facebook/internal/NativeProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/NativeProtocol.java
@@ -204,6 +204,7 @@ public final class NativeProtocol {
     // EXTRA_PERMISSIONS
 
     public static final String RESULT_ARGS_ACCESS_TOKEN = "access_token";
+    public static final String RESULT_ARGS_GRAPH_DOMAIN = "graph_domain";
     public static final String RESULT_ARGS_SIGNED_REQUEST = "signed request";
     public static final String RESULT_ARGS_EXPIRES_SECONDS_SINCE_EPOCH =
         "expires_seconds_since_epoch";

--- a/facebook-core/src/main/java/com/facebook/internal/ServerProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/ServerProtocol.java
@@ -63,7 +63,7 @@ public final class ServerProtocol {
     public static final String DIALOG_PARAM_STATE = "state";
     public static final String DIALOG_REREQUEST_AUTH_TYPE = "rerequest";
     public static final String DIALOG_RESPONSE_TYPE_TOKEN_AND_SIGNED_REQUEST
-            = "token,signed_request";
+            = "token,signed_request,graph_domain";
     public static final String DIALOG_RETURN_SCOPES_TRUE = "true";
     public static final String DIALOG_REDIRECT_URI = "fbconnect://success";
     public static final String DIALOG_REDIRECT_CHROME_OS_URI = "fbconnect://chrome_os_success";

--- a/facebook/src/test/java/com/facebook/GraphRequestTest.java
+++ b/facebook/src/test/java/com/facebook/GraphRequestTest.java
@@ -75,6 +75,7 @@ public class GraphRequestTest extends FacebookPowerMockTestCase {
         Whitebox.setInternalState(FacebookSdk.class, "sdkInitialized", true);
         Whitebox.setInternalState(FacebookSdk.class, "applicationId", mockAppID);
         Whitebox.setInternalState(FacebookSdk.class, "appClientToken", mockClientToken);
+        when(FacebookSdk.getApplicationContext()).thenReturn(RuntimeEnvironment.application);
     }
 
     @Test


### PR DESCRIPTION
Summary:
Access Tokens can now be granted for specific domains.
This updates the SDK to use 'fb.gg' when the graph_domain is 'gaming' for an AccessToken.

Differential Revision: D19563997

