### PR TITLE
[BUG] AndroidX Custom Tab Issue Fix

### DIFF
--- a/facebook-common/src/main/java/com/facebook/login/CustomTabLoginMethodHandler.java
+++ b/facebook-common/src/main/java/com/facebook/login/CustomTabLoginMethodHandler.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.customtabs.CustomTabsService;
 
 import com.facebook.AccessTokenSource;
 import com.facebook.CustomTabMainActivity;
@@ -53,8 +54,6 @@ public class CustomTabLoginMethodHandler extends WebLoginMethodHandler {
     private static final int CUSTOM_TAB_REQUEST_CODE = 1;
     private static final int CHALLENGE_LENGTH = 20;
     private static final int API_EC_DIALOG_CANCEL = 4201;
-    private static final String CUSTOM_TABS_SERVICE_ACTION =
-            "android.support.customtabs.action.CustomTabsService";
     private static final String[] CHROME_PACKAGES = {
             "com.android.chrome",
             "com.chrome.beta",
@@ -146,7 +145,7 @@ public class CustomTabLoginMethodHandler extends WebLoginMethodHandler {
             return currentPackage;
         }
         Context context = loginClient.getActivity();
-        Intent serviceIntent = new Intent(CUSTOM_TABS_SERVICE_ACTION);
+        Intent serviceIntent = new Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
         List<ResolveInfo> resolveInfos =
                 context.getPackageManager().queryIntentServices(serviceIntent, 0);
         if (resolveInfos != null) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details
Custom Tab has to be working for AndroidX enabled projects

## Expected Results
What do you expect to happen?
If the Facebook app is not installed, then on click of the Facebook login button in App, Custom Chrome Tab has to be open.

## Actual Results
What actually happened? Can you provide a stack trace?
If the Facebook app is not installed, then on click of Facebook login button in App, by default WebView is opening instead of Custom Chrome Tab even I have enabled the Custom Tab for my project.

## Steps to Reproduce
What are the steps necessary to reproduce this issue?
Integrate Facebook Login Button in App
Uninstall Facebook App from the Device
Make sure your project is migrated to AndroidX.
Click on the "Login With Facebook" button, WebView is opening instead of Custom Chrome Tab

Please merge the Pull Requests, so that we can use the Custom Chrome Tab in Facebook SDK for AndroidX Projects