### PR TITLE
Add GamingServices as a dependency of the root Facebook package

### DIFF
--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     api project(":facebook-places")
     api project(":facebook-applinks")
     api project(":facebook-messenger")
+    api project(":facebook-gamingservices")
     // @fb-only: api project(":facebook-marketing")
 
     // Unit Tests


### PR DESCRIPTION
Summary: This change will make GamingServices a dependency of the root Facebook package so that it gets pulled via Maven.

Differential Revision: D20240472

