### PR TITLE
throw exception when facebookAppId is placed in AndroidManifext.xml without 'fb' prefix.

### DIFF
--- a/facebook-core/src/main/java/com/facebook/FacebookSdk.java
+++ b/facebook-core/src/main/java/com/facebook/FacebookSdk.java
@@ -795,7 +795,7 @@ public final class FacebookSdk {
                 } else {
                     applicationId = appIdString;
                 }
-            } else if (appId instanceof Integer) {
+            } else if (appId instanceof Number) {
                 throw new FacebookException(
                         "App Ids cannot be directly placed in the manifest." +
                         "They must be prefixed by 'fb' or be placed in the string resource file.");


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

In some cases, facebookAppId in AndroidManifest.xml is treated as Float if it is placed directly in AndroidManifest.xml.
We should throw exception in that case.
