### PR TITLE
Bump support libraries to 28.0.0

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -21,7 +21,7 @@
 project.ext {
     gradleVersion = "3.1.2"
     buildTools = "28.0.0"
-    supportLibraryVersion = "27.0.2"
+    supportLibraryVersion = "28.0.0"
     compileSdk = 28
     minSdk = 15
     targetSdk = 28

--- a/samples/FBLoginSample/build.gradle
+++ b/samples/FBLoginSample/build.gradle
@@ -21,12 +21,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "27.0.3"
+    compileSdkVersion project.ext.compileSdk
+    buildToolsVersion project.ext.buildTools
     defaultConfig {
         applicationId "com.facebook.fbloginsample"
-        minSdkVersion 15
-        targetSdkVersion 26
+        minSdkVersion project.ext.minSdk
+        targetSdkVersion project.ext.targetSdk
         versionCode 1
         versionName "0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -56,8 +56,8 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':facebook')
     implementation 'com.facebook.fresco:fresco:0.14.0'
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support:support-annotations:27.0.2'
+    implementation "com.android.support:appcompat-v7:${project.ext.supportLibraryVersion}"
+    implementation "com.android.support:support-annotations:${project.ext.supportLibraryVersion}"
 
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/samples/RPSSample/build.gradle
+++ b/samples/RPSSample/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation project(':facebook-login')
     implementation project(':facebook-share')
     implementation project(':facebook-applinks')
-    implementation 'com.android.support:design:27.1.1'
+    implementation "com.android.support:design:${project.ext.supportLibraryVersion}"
 }
 
 android {


### PR DESCRIPTION
- Prepare SDK for Jetifier tool which requires 28.0.0 version of the support libraries
- Update sample apps to use the constants

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details
Bump support libraries to 28.0.0 to support Jetifier https://developer.android.com/studio/command-line/jetifier

Would like to be able to use the Jetifier internally on this library but the requirement is 28.0.0
