### PR TITLE
Add MonitorLoggingManager class

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/LoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LoggingManager.java
@@ -25,5 +25,14 @@ package com.facebook.internal.logging;
  */
 public interface LoggingManager {
     void addLog(ExternalLog log);
+
+    /**
+     * Send logs from LoggingCache to server, and empty LoggingCache
+     */
     void flushAndWait();
+
+    /**
+     * Read logs from the file, delete the file and send the logs to the server
+     */
+    void flushLoggingStore();
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.internal.logging.monitor;
+
+import android.support.annotation.Nullable;
+
+import com.facebook.FacebookSdk;
+import com.facebook.GraphRequest;
+import com.facebook.GraphRequestBatch;
+import com.facebook.internal.Utility;
+import com.facebook.internal.logging.ExternalLog;
+import com.facebook.internal.logging.LoggingCache;
+import com.facebook.internal.logging.LoggingManager;
+import com.facebook.internal.logging.LoggingStore;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * MonitorLoggingManager deals with all new logs and the logs storing in the memory and the disk.
+ * The new log will be added into MonitorLoggingQueue.
+ * The MonitorLoggingManger will do the next step depending on if the MonitorLoggingQueue has
+ * reached the flush limit after adding new log(s). If yes, MonitorLoggingManager will send the
+ * logs back to our server. If not, MonitorLoggingManager will schedule a future task of sending
+ * logs at regular intervals.
+ *
+ * Each GraphRequest can have 20 logs in the parameter in maximum.
+ * We send the GraphRequest(s) using GraphRequestBatch call.
+ */
+public class MonitorLoggingManager implements LoggingManager {
+    private static final int FLUSH_PERIOD = 60;    // in second
+    private static final Integer MAX_LOG_NUMBER_PER_REQUEST = 100;
+    private static final String ENTRIES_KEY = "entries";
+    private static final String MONITORING_ENDPOINT = "monitorings";
+    private final ScheduledExecutorService singleThreadExecutor =
+            Executors.newSingleThreadScheduledExecutor();
+    private static MonitorLoggingManager monitorLoggingManager;
+    private LoggingCache logQueue;
+    private LoggingStore logStore;
+    private ScheduledFuture flushTimer;
+
+    // Only call for the singleThreadExecutor
+    private final Runnable flushRunnable = new Runnable() {
+        @Override
+        public void run() {
+            flushAndWait();
+        }
+    };
+
+    private MonitorLoggingManager(LoggingCache monitorLoggingQueue, LoggingStore monitorLoggingStore) {
+        if (logQueue == null) {
+            this.logQueue = monitorLoggingQueue;
+        }
+        if (logStore == null) {
+            this.logStore = monitorLoggingStore;
+        }
+    }
+
+    public synchronized static MonitorLoggingManager getInstance(LoggingCache monitorLoggingQueue, LoggingStore logStore) {
+        if (monitorLoggingManager == null) {
+            monitorLoggingManager = new MonitorLoggingManager(monitorLoggingQueue, logStore);
+        }
+        return monitorLoggingManager;
+    }
+
+    @Override
+    public void addLog(final ExternalLog log) {
+        singleThreadExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                if (logQueue.addLog(log)) {
+                    flushAndWait();
+                } else if (flushTimer == null) {
+                    flushTimer = singleThreadExecutor.schedule(
+                            flushRunnable,
+                            FLUSH_PERIOD,
+                            TimeUnit.SECONDS);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void flushAndWait() {
+        if (flushTimer != null) {
+            flushTimer.cancel(true);
+        }
+
+        // build requests
+        List<GraphRequest> requests = buildRequests(logQueue);
+        try {
+            new GraphRequestBatch(requests).executeAsync();
+        } catch (Exception e) {
+            // swallow Exception to avoid user's app to crash
+        }
+    }
+
+    // will be called once the Monitor is enabled
+    @Override
+    public void flushLoggingStore() {
+        List<ExternalLog> logsReadFromStore = logStore.readAndClearStore();
+        logQueue.addLogs(logsReadFromStore);
+        flushAndWait();
+    }
+
+    static List<GraphRequest> buildRequests(LoggingCache monitorLoggingQueue) {
+        List<GraphRequest> requests = new ArrayList<>();
+        String appID = FacebookSdk.getApplicationId();
+
+        // Check App ID is not null
+        if (Utility.isNullOrEmpty(appID)) {
+            return requests;
+        }
+
+        while (!monitorLoggingQueue.isEmpty()) {
+            final List<ExternalLog> logsReadyToBeSend = new ArrayList<>();
+
+            // each GraphRequest contains MAX_LOG_NUMBER_PER_REQUEST of logs
+            for (int i = 0; i < MAX_LOG_NUMBER_PER_REQUEST && !monitorLoggingQueue.isEmpty(); i++) {
+                ExternalLog log = monitorLoggingQueue.fetchLog();
+                logsReadyToBeSend.add(log);
+            }
+
+            GraphRequest postRequest = buildPostRequestFromLogs(logsReadyToBeSend);
+            if (postRequest != null) {
+                requests.add(postRequest);
+            }
+        }
+        return requests;
+    }
+
+    @Nullable
+    static GraphRequest buildPostRequestFromLogs(List<? extends ExternalLog> logs) {
+        JSONArray logsToParams = new JSONArray();
+
+        for (ExternalLog log : logs) {
+            logsToParams.put(log.convertToJSONObject());
+        }
+
+        if (logsToParams.length() == 0) {
+            return null;
+        }
+
+        JSONObject params = new JSONObject();
+        try {
+            params.put(ENTRIES_KEY, logsToParams);
+        } catch (JSONException e) {
+            return null;
+        }
+
+        return GraphRequest.newPostRequest(
+                null,
+                String.format("%s/" + MONITORING_ENDPOINT, FacebookSdk.getApplicationId()),
+                params,
+                null);
+    }
+}

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingManagerTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingManagerTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.internal.logging.monitor;
+
+import com.facebook.FacebookPowerMockTestCase;
+import com.facebook.FacebookSdk;
+import com.facebook.GraphRequest;
+import com.facebook.GraphRequestBatch;
+import com.facebook.internal.logging.ExternalLog;
+import com.facebook.internal.logging.LoggingCache;
+import com.facebook.internal.logging.LoggingStore;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.reflect.Whitebox;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.util.ReflectionHelpers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_APP_ID;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_TIME_START;
+import static java.lang.Thread.sleep;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+@PrepareForTest({
+        FacebookSdk.class,
+        MonitorLoggingManager.class,
+        GraphRequest.class,
+})
+public class MonitorLoggingManagerTest extends FacebookPowerMockTestCase {
+
+    @Mock
+    private LoggingCache mockMonitorLoggingQueue;
+    @Mock
+    private LoggingStore mockMonitorLoggingStore;
+    @Mock
+    private MonitorLoggingManager mockMonitorLoggingManager;
+    private ScheduledExecutorService mockExecutor;
+    private MonitorLog monitorLog;
+    private static final int TEST_MAX_LOG_NUMBER_PER_REQUEST = 3;
+    private static final int TIMES = 2;
+
+    @Before
+    public void init() {
+        spy(FacebookSdk.class);
+        when(FacebookSdk.isInitialized()).thenReturn(true);
+        PowerMockito.when(FacebookSdk.getApplicationContext()).thenReturn(
+                RuntimeEnvironment.application);
+
+        MonitorLoggingQueue monitorLoggingQueue = MonitorLoggingQueue.getInstance();
+        mockMonitorLoggingQueue = Mockito.spy(monitorLoggingQueue);
+        MonitorLoggingManager monitorLoggingManager = MonitorLoggingManager.getInstance(
+                mockMonitorLoggingQueue, mockMonitorLoggingStore);
+        mockExecutor = Mockito.spy(new FacebookSerialThreadPoolExecutor(1));
+
+        mock(Executors.class);
+        Whitebox.setInternalState(monitorLoggingManager, "singleThreadExecutor", mockExecutor);
+        Whitebox.setInternalState(monitorLoggingManager, "logQueue", mockMonitorLoggingQueue);
+        mockMonitorLoggingManager = Mockito.spy(monitorLoggingManager);
+        monitorLog = MonitorLoggingTestUtil.getTestMonitorLog(TEST_TIME_START);
+    }
+
+    @Test
+    public void testAddLogThenHasNotReachedFlushLimit() throws InterruptedException {
+        when(mockMonitorLoggingQueue.addLog(any(ExternalLog.class))).thenReturn(false);
+        mockMonitorLoggingManager.addLog(monitorLog);
+
+        // make sure that singleThreadExecutor has been scheduled a future task successfully
+        sleep(300);
+        verify(mockExecutor).schedule(any(Runnable.class), anyInt(), any(TimeUnit.class));
+    }
+
+    @Test
+    public void testAddLogThenHasReachedFlushLimit() {
+        when(mockMonitorLoggingQueue.addLog(any(ExternalLog.class))).thenReturn(true);
+        mockMonitorLoggingManager.addLog(monitorLog);
+
+        verify(mockMonitorLoggingQueue).addLog(monitorLog);
+        verify(mockMonitorLoggingManager).flushAndWait();
+    }
+
+    @Test
+    public void testFlushAndWait() {
+        PowerMockito.mockStatic(GraphRequest.class);
+        PowerMockito.mockStatic(MonitorLoggingManager.class);
+        spy(MonitorLoggingManager.class);
+        when(FacebookSdk.getApplicationId()).thenReturn(TEST_APP_ID);
+
+        mockMonitorLoggingManager.flushAndWait();
+        PowerMockito.verifyStatic();
+        GraphRequest.executeBatchAsync(any(GraphRequestBatch.class));
+
+        PowerMockito.verifyStatic();
+        MonitorLoggingManager.buildRequests(any(MonitorLoggingQueue.class));
+    }
+
+    @Test
+    public void testBuildRequestsWhenAppIDIsNull() {
+        when(FacebookSdk.getApplicationId()).thenReturn(null);
+        List<GraphRequest> requests = MonitorLoggingManager.buildRequests(mockMonitorLoggingQueue);
+        verifyNoMoreInteractions(mockMonitorLoggingQueue);
+        Assert.assertEquals(0, requests.size());
+    }
+
+    @Test
+    public void testBuildRequestsWhenAppIDIsNotNull() {
+        when(FacebookSdk.getApplicationId()).thenReturn(TEST_APP_ID);
+        ReflectionHelpers.setStaticField(MonitorLoggingManager.class, "MAX_LOG_NUMBER_PER_REQUEST", TEST_MAX_LOG_NUMBER_PER_REQUEST);
+        for (int i = 0; i < TEST_MAX_LOG_NUMBER_PER_REQUEST * TIMES; i++) {
+            mockMonitorLoggingManager.addLog(monitorLog);
+        }
+
+        List<GraphRequest> requests = MonitorLoggingManager.buildRequests(mockMonitorLoggingQueue);
+        verify(mockMonitorLoggingQueue, times(TEST_MAX_LOG_NUMBER_PER_REQUEST * TIMES)).fetchLog();
+        Assert.assertEquals(TIMES, requests.size());
+    }
+
+    @Test
+    public void testBuildPostRequestFromLogs() {
+        GraphRequest request = MonitorLoggingManager.buildPostRequestFromLogs(Arrays.asList(monitorLog));
+        Assert.assertNotNull(request);
+    }
+
+    @After
+    public void tearDown() {
+        mockExecutor.shutdown();
+        reset(mockMonitorLoggingQueue);
+
+        // empty mockMonitorLoggingQueue
+        while (!mockMonitorLoggingQueue.isEmpty()) {
+            mockMonitorLoggingQueue.fetchLog();
+        }
+    }
+}


### PR DESCRIPTION
Summary:
New log will be passed in MonitorLoggingManager via Monitor.
The MonitorLoggingManager adds the new log to the MonitorLoggingQueue. If the MonitorLoggingQueue has reached the flush limit, the MonitorLoggingManager will flush the MonitorLoggingQueue and send the logs back to our server. If not, MonitorLoggingManager will schedule a future task of sending logs in 60 second.

Each PostGraphRequest contains 20 logs in the parameter in maximum. After all of the logs are built as PostGraphRequests, they will be sent to our server using Batch call.

Using single-threaded Executor to make sure flushAndWait() will be executed safely. Single-threaded Executor can guarantee that no more than one task will be active at any given time.

https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html#newSingleThreadExecutor()

Reviewed By: Mxiim

Differential Revision: D20689760

