### PR TITLE
Fix GamingImageUploader callback when mediaDialog=false

### DIFF
--- a/facebook-gamingservices/src/main/java/com/facebook/gamingservices/GamingImageUploader.java
+++ b/facebook-gamingservices/src/main/java/com/facebook/gamingservices/GamingImageUploader.java
@@ -192,9 +192,9 @@ public class GamingImageUploader {
     ) throws FileNotFoundException {
         AccessToken accessToken = AccessToken.getCurrentAccessToken();
 
-        GraphRequest.Callback openMediaCallback = null;
+        GraphRequest.Callback requestCallback = callback;
         if (shouldLaunchMediaDialog) {
-            openMediaCallback = new OpenGamingMediaDialog(this.context, callback);
+            requestCallback = new OpenGamingMediaDialog(this.context, callback);
         }
 
         GraphRequest.newUploadPhotoRequest(
@@ -203,6 +203,6 @@ public class GamingImageUploader {
                 imageUri,
                 caption,
                 null,
-                openMediaCallback).executeAsync();
+                requestCallback).executeAsync();
     }
 }


### PR DESCRIPTION
Summary: When shouldOpenMediaDialog = false. the ImageUploader would not call the provided callback (if any). This fixes that.

Reviewed By: Mxiim

Differential Revision: D20806519

