### PR TITLE
Move device related info to overall payload

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
@@ -20,7 +20,6 @@
 
 package com.facebook.internal.logging.monitor;
 
-import android.os.Build;
 import android.support.annotation.Nullable;
 
 import com.facebook.FacebookSdk;
@@ -50,8 +49,6 @@ public class MonitorLog implements ExternalLog {
     private long timeStart;
     private int timeSpent;
     private String sampleAppInformation;
-    private String deviceOSVersion;
-    private String deviceModel;
 
     // Lazily initialized hashcode.
     private int hashCode;
@@ -77,8 +74,6 @@ public class MonitorLog implements ExternalLog {
     }
 
     public MonitorLog(LogBuilder logBuilder) {
-        this.deviceOSVersion = Build.VERSION.RELEASE;
-        this.deviceModel = Build.MODEL;
         this.event = logBuilder.event;
         this.timeStart = logBuilder.timeStart;
         this.timeSpent = logBuilder.timeSpent;
@@ -86,14 +81,6 @@ public class MonitorLog implements ExternalLog {
         if (packageName != null && isSampleApp(packageName)) {
             sampleAppInformation = packageName;
         }
-    }
-
-    public String getDeviceOSVersion() {
-        return this.deviceOSVersion;
-    }
-
-    public String getDeviceModel() {
-        return this.deviceModel;
     }
 
     public MonitorEvent getEvent() {
@@ -157,14 +144,10 @@ public class MonitorLog implements ExternalLog {
     public String toString() {
         String format = ": %s";
         return String.format(
-                PARAM_DEVICE_OS_VERSION + format + ", "
-                        + PARAM_DEVICE_MODEL + format + ", "
-                        + PARAM_EVENT_NAME + format + ", "
+                PARAM_EVENT_NAME + format + ", "
                         + PARAM_SAMPLE_APP_INFO + format + ", "
                         + PARAM_TIME_START + format + ", "
                         + PARAM_TIME_SPENT + format,
-                deviceOSVersion,
-                deviceModel,
                 event,
                 sampleAppInformation,
                 timeStart,
@@ -175,8 +158,6 @@ public class MonitorLog implements ExternalLog {
     public int hashCode() {
         if (hashCode == 0) {
             int result = 17;
-            result = 31 * result + (deviceOSVersion != null ? deviceOSVersion.hashCode() : 0);
-            result = 31 * result + (deviceModel != null ? deviceModel.hashCode() : 0);
             result = 31 * result + (event != null ? event.hashCode() : 0);
             result = 31 * result + (sampleAppInformation != null ? sampleAppInformation.hashCode() : 0);
             result = 31 * result + (int) (timeStart ^ (timeStart >>> 32));
@@ -195,9 +176,7 @@ public class MonitorLog implements ExternalLog {
             return false;
         }
         MonitorLog other = (MonitorLog) obj;
-        return deviceOSVersion.equals(other.deviceOSVersion)
-                && deviceModel.equals(other.deviceModel)
-                && event == other.event
+        return event == other.event
                 && timeStart == other.timeStart
                 && timeSpent == other.timeSpent
                 && ((sampleAppInformation == null && other.sampleAppInformation == null)
@@ -208,8 +187,6 @@ public class MonitorLog implements ExternalLog {
     public JSONObject convertToJSONObject() {
         JSONObject object = new JSONObject();
         try {
-            object.put(PARAM_DEVICE_OS_VERSION, deviceOSVersion);
-            object.put(PARAM_DEVICE_MODEL, deviceModel);
             object.put(PARAM_EVENT_NAME, event.getName());
 
             if (timeStart != 0) {

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -20,6 +20,7 @@
 
 package com.facebook.internal.logging.monitor;
 
+import android.os.Build;
 import android.support.annotation.Nullable;
 
 import com.facebook.FacebookSdk;
@@ -41,6 +42,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_MODEL;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_OS_VERSION;
 
 /**
  * MonitorLoggingManager deals with all new logs and the logs storing in the memory and the disk.
@@ -64,6 +68,15 @@ public class MonitorLoggingManager implements LoggingManager {
     private LoggingCache logQueue;
     private LoggingStore logStore;
     private ScheduledFuture flushTimer;
+
+    // device information
+    private static String deviceOSVersion;
+    private static String deviceModel;
+
+    static {
+        deviceOSVersion = Build.VERSION.RELEASE;
+        deviceModel = Build.MODEL;
+    }
 
     // Only call for the singleThreadExecutor
     private final Runnable flushRunnable = new Runnable() {
@@ -169,6 +182,8 @@ public class MonitorLoggingManager implements LoggingManager {
 
         JSONObject params = new JSONObject();
         try {
+            params.put(PARAM_DEVICE_OS_VERSION, deviceOSVersion);
+            params.put(PARAM_DEVICE_MODEL, deviceModel);
             params.put(ENTRIES_KEY, logsToParams);
         } catch (JSONException e) {
             return null;

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLogTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLogTest.java
@@ -57,7 +57,6 @@ public class MonitorLogTest extends FacebookPowerMockTestCase {
         when(FacebookSdk.isInitialized()).thenReturn(true);
         PowerMockito.when(FacebookSdk.getApplicationContext()).thenReturn(
                 RuntimeEnvironment.application);
-        ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", 15);
     }
 
     @Test
@@ -67,9 +66,6 @@ public class MonitorLogTest extends FacebookPowerMockTestCase {
                 .timeSpent(TEST_TIME_SPENT)
                 .build();
 
-        Assert.assertNotNull(log.getDeviceOSVersion());
-        Assert.assertNotNull(log.getDeviceModel());
-        Assert.assertEquals(TIME_START, log.getTimeStart());
         Assert.assertEquals(FB_CORE_STARTUP, log.getEvent());
         Assert.assertEquals(TIME_START, log.getTimeStart());
         Assert.assertEquals(TEST_TIME_SPENT, log.getTimeSpent());
@@ -88,8 +84,6 @@ public class MonitorLogTest extends FacebookPowerMockTestCase {
 
     @Test
     public void testConvertToJSONObject() throws JSONException {
-        String DEVICE_OS_VERSION = Build.VERSION.RELEASE;
-        String DEVICE_MODEL = Build.MODEL;
         MonitorLog log = MonitorLoggingTestUtil.getTestMonitorLog(TIME_START);
         Assert.assertEquals(FB_CORE_STARTUP, log.getEvent());
         JSONObject json = log.convertToJSONObject();
@@ -97,8 +91,6 @@ public class MonitorLogTest extends FacebookPowerMockTestCase {
         Assert.assertEquals(TIME_START, json.getLong(PARAM_TIME_START));
         Assert.assertEquals(FB_CORE_STARTUP.getName(), json.getString(PARAM_EVENT_NAME));
         Assert.assertEquals(TEST_TIME_SPENT, json.getInt(PARAM_TIME_SPENT));
-        Assert.assertEquals(DEVICE_OS_VERSION, json.getString(PARAM_DEVICE_OS_VERSION));
-        Assert.assertEquals(DEVICE_MODEL, json.getString(PARAM_DEVICE_MODEL));
 
         try {
             json.getString(PARAM_SAMPLE_APP_INFO);


### PR DESCRIPTION
Summary: Move device related info to overall payload from MonitorLog to MonitorLoggingManager, since it will be the same for each log.

Reviewed By: joesus

Differential Revision: D20812553

