### PR TITLE
Remove MonitorEvent class and modify MonitorLog

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/LogCategory.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LogCategory.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
- *
+ * <p>
  * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
  * copy, modify, and distribute this software in source code or binary form for use
  * in connection with the web services and APIs provided by Facebook.
- *
+ * <p>
  * As with any software that integrates with the Facebook platform, your use of
  * this software is subject to the Facebook Developer Principles and Policies
  * [http://developers.facebook.com/policy/]. This copyright notice shall be
  * included in all copies or substantial portions of the software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -18,36 +18,12 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package com.facebook.internal.logging.monitor;
+package com.facebook.internal.logging;
 
 /**
- *  MonitorEvent contains a name which should be consistent to the attribute at endpoint.
- *  The integer samplingRate indicates how often we process and send the log of a particular
- *  MonitorEvent type.
- *  For example, if samplingRate equals 5, we will send the log every 5 logs
- *  which have the same MonitorEvent type.
+ * Log category shows the log's category
  */
-public enum MonitorEvent {
-    FB_CORE_STARTUP("fb_core_startup", 1);
-
-    private String name;
-    private int samplingRate;
-
-    MonitorEvent(String name, int samplingRate) {
-        this.name = name;
-        this.samplingRate = samplingRate;
-    }
-
-    public int getSamplingRate() {
-        return samplingRate;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
+public enum LogCategory {
+    PERFORMANCE,
+    METHOD_USAGE,
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/LogEvent.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LogEvent.java
@@ -1,15 +1,15 @@
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
- *
+ * <p>
  * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
  * copy, modify, and distribute this software in source code or binary form for use
  * in connection with the web services and APIs provided by Facebook.
- *
+ * <p>
  * As with any software that integrates with the Facebook platform, your use of
  * this software is subject to the Facebook Developer Principles and Policies
  * [http://developers.facebook.com/policy/]. This copyright notice shall be
  * included in all copies or substantial portions of the software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -20,27 +20,34 @@
 
 package com.facebook.internal.logging;
 
-import org.json.JSONObject;
 import java.io.Serializable;
 
 /**
- *  ExternalLog will will be sent back to the server
+ * Log event contains event name and category.
+ * Event name indicates which event/method is tracked, sampling rate is event-basis.
+ * Category indicates which category the log belongs to, we can add validator for each category if
+ * needed.
  */
-public interface ExternalLog extends Serializable {
+public class LogEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private String eventName;
+    private LogCategory logCategory;
 
-    /**
-     *  convert the log to an JSONObject for putting multiple logs in a JSONArray as a part of
-     *  POST Request's parameter in a single request later
-     */
-    JSONObject convertToJSONObject();
+    public LogEvent(String eventName, LogCategory logCategory) {
+        this.eventName = eventName;
+        this.logCategory = logCategory;
+    }
 
-    /**
-     * @return the tracked event name
-     */
-    String getEventName();
+    public String getEventName() {
+        return this.eventName;
+    }
 
-    /**
-     * @return log's category, e.g. PERFORMANCE
-     */
-    LogCategory getLogCategory();
+    public LogCategory getLogCategory() {
+        return logCategory;
+    }
+
+    public String upperCaseEventName() {
+        this.eventName = eventName.toUpperCase();
+        return this.eventName;
+    }
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
@@ -2,9 +2,10 @@ package com.facebook.internal.logging.monitor;
 
 public class MonitorLogServerProtocol {
     public static final String PARAM_EVENT_NAME = "event_name";
+    public static final String PARAM_CATEGORY = "category";
+    public static final String PARAM_UNIQUE_APPLICATION_ID = "unique_application_identifier";
     public static final String PARAM_DEVICE_MODEL = "device_model";
     public static final String PARAM_DEVICE_OS_VERSION = "device_os_version";
-    public static final String PARAM_SAMPLE_APP_INFO = "sample_app_info";
     public static final String PARAM_TIME_START = "time_start";
     public static final String PARAM_TIME_SPENT = "time_spent";
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_MODEL;
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_OS_VERSION;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_UNIQUE_APPLICATION_ID;
 
 /**
  * MonitorLoggingManager deals with all new logs and the logs storing in the memory and the disk.
@@ -54,7 +55,7 @@ import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PAR
  * logs back to our server. If not, MonitorLoggingManager will schedule a future task of sending
  * logs at regular intervals.
  *
- * Each GraphRequest can have 20 logs in the parameter in maximum.
+ * Each GraphRequest can have limited number of logs in the parameter in maximum.
  * We send the GraphRequest(s) using GraphRequestBatch call.
  */
 public class MonitorLoggingManager implements LoggingManager {
@@ -170,6 +171,7 @@ public class MonitorLoggingManager implements LoggingManager {
 
     @Nullable
     static GraphRequest buildPostRequestFromLogs(List<? extends ExternalLog> logs) {
+        String packageName = FacebookSdk.getApplicationContext().getPackageName();
         JSONArray logsToParams = new JSONArray();
 
         for (ExternalLog log : logs) {
@@ -184,6 +186,7 @@ public class MonitorLoggingManager implements LoggingManager {
         try {
             params.put(PARAM_DEVICE_OS_VERSION, deviceOSVersion);
             params.put(PARAM_DEVICE_MODEL, deviceModel);
+            params.put(PARAM_UNIQUE_APPLICATION_ID, packageName);
             params.put(ENTRIES_KEY, logsToParams);
         } catch (JSONException e) {
             return null;

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingManagerTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingManagerTest.java
@@ -20,6 +20,7 @@
 
 package com.facebook.internal.logging.monitor;
 
+import android.content.Context;
 import android.os.Build;
 
 import com.facebook.FacebookPowerMockTestCase;
@@ -52,7 +53,9 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_MODEL;
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_DEVICE_OS_VERSION;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_UNIQUE_APPLICATION_ID;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_APP_ID;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_PACKAGE_NAME;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_TIME_START;
 import static java.lang.Thread.sleep;
 import static org.mockito.Matchers.any;
@@ -91,6 +94,9 @@ public class MonitorLoggingManagerTest extends FacebookPowerMockTestCase {
         PowerMockito.when(FacebookSdk.getApplicationContext()).thenReturn(
                 RuntimeEnvironment.application);
         ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", 15);
+        Context mockApplicationContext = mock(Context.class);
+        when(FacebookSdk.getApplicationContext()).thenReturn(mockApplicationContext);
+        when(mockApplicationContext.getPackageName()).thenReturn(TEST_PACKAGE_NAME);
 
         MonitorLoggingQueue monitorLoggingQueue = MonitorLoggingQueue.getInstance();
         mockMonitorLoggingQueue = Mockito.spy(monitorLoggingQueue);
@@ -166,8 +172,10 @@ public class MonitorLoggingManagerTest extends FacebookPowerMockTestCase {
         JSONObject graphObject = request.getGraphObject();
         String deviceOsVersion = Build.VERSION.RELEASE;
         String deviceModel = Build.MODEL;
+
         Assert.assertEquals(deviceOsVersion, graphObject.getString(PARAM_DEVICE_OS_VERSION));
         Assert.assertEquals(deviceModel, graphObject.getString(PARAM_DEVICE_MODEL));
+        Assert.assertEquals(TEST_PACKAGE_NAME, graphObject.getString(PARAM_UNIQUE_APPLICATION_ID));
         Assert.assertNotNull(graphObject.getString(ENTRIES_KEY));
     }
 

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
@@ -1,16 +1,23 @@
 package com.facebook.internal.logging.monitor;
 
-import static com.facebook.internal.logging.monitor.MonitorEvent.FB_CORE_STARTUP;
+import com.facebook.internal.logging.LogCategory;
+import com.facebook.internal.logging.LogEvent;
 
 public class MonitorLoggingTestUtil {
-    public static final String TEST_APP_ID = "TEST_APP_ID";
-    public static final int TEST_TIME_SPENT = 20000;
-    public static final int TEST_TIME_START = 100;
-    public static final int TEST_INVALID_TIME_SPENT = -50;
-    public static final long TEST_INVALID_TIME_START = -100;
+    static final String TEST_APP_ID = "TEST_APP_ID";
+    static final LogCategory TEST_CATEGORY = LogCategory.PERFORMANCE;
+    static final int TEST_TIME_SPENT = 20000;
+    static final int TEST_TIME_START = 100;
+    static final int TEST_INVALID_TIME_SPENT = -50;
+    static final long TEST_INVALID_TIME_START = -100;
+    static final String TEST_EVENT_NAME = "FB_CORE_STARTUP";
+    static final String TEST_PACKAGE_NAME = "com.facebook.fbloginsample";
+    static final int INVALID_TIME = -1;
+    static final long INVALID_TIME_LONG = -1;
+    static final LogEvent TEST_LOG_EVENT = new LogEvent(TEST_EVENT_NAME, TEST_CATEGORY);
 
     public static MonitorLog getTestMonitorLog(long timeStart, int timeSpent) {
-        MonitorLog log = new MonitorLog.LogBuilder(FB_CORE_STARTUP)
+        MonitorLog log = new MonitorLog.LogBuilder(TEST_LOG_EVENT)
                 .timeStart(timeStart)
                 .timeSpent(timeSpent)
                 .build();


### PR DESCRIPTION
Summary:
Since we added category attribute, and decided to track unique application id which is the package name for Android, I added these new fields in `MonitorLog` class.

`MonitorLog` has a required attribute `LogEvent` which contains event name and category. If the category is `PERFORMANCE`, the event name should be one of the values in `validPerformanceEventNames` Set.

Also, I removed `MonitorEvent`, because we want to track the usage of method in the future. The method name will be stored under event name field, using pattern className::methodName. We can't make the `MonitorEvent` as an Enum any more.

Reviewed By: Mxiim

Differential Revision: D20775666

