### PR TITLE
Add Monitor class

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.facebook.internal.logging.monitor;
+
+import android.os.Bundle;
+
+import com.facebook.FacebookSdk;
+import com.facebook.GraphRequest;
+import com.facebook.internal.logging.ExternalLog;
+import com.facebook.internal.logging.LoggingManager;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.APPLICATION_FIELDS;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.DEFAULT_SAMPLE_RATES_KEY;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.MONITOR_CONFIG;
+import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.SAMPLE_RATES;
+
+/**
+ * Monitor is the entry point of the Monitoring System. Once Monitor is enabled, we will fetch the
+ * sampling rates from the server and flush the disk (send the logs to the server and clean the disk).
+ */
+public class Monitor {
+    private static final Random random = new Random();
+
+    // in case we can't fetch the sampling rate from the server
+    private static Integer defaultSamplingRate = 1000;
+
+    private static boolean isEnabled;
+    private static final LoggingManager monitorLoggingManager = MonitorLoggingManager.getInstance(
+            MonitorLoggingQueue.getInstance(), MonitorLoggingStore.getInstance());
+    private static final Map<String, Integer> samplingRatesMap = new HashMap<>();
+
+    private Monitor() {
+    }
+
+    /**
+     * Enable Monitor will fetch the sampling rates from the server and send the logs from
+     * MonitorLoggingStore
+     */
+    public static void enable() {
+        if (isEnabled) {
+            return;
+        }
+        isEnabled = true;
+
+        // pull down the sampling rates, update samplingRatesMap
+        loadSamplingRatesMapAsync();
+
+        // flush disk
+        monitorLoggingManager.flushLoggingStore();
+    }
+
+    /**
+     * fetch the sampling rates from the server and update SamplingRatesMap
+     */
+    public static void loadSamplingRatesMapAsync() {
+        FacebookSdk.getExecutor().execute(new Runnable() {
+            @Override
+            public void run() {
+                JSONObject samplingRates = fetchSamplingRate();
+                if (samplingRates != null) {
+                    updateSamplingRateMap(samplingRates);
+                }
+            }
+        });
+    }
+
+    /**
+     * send the request of fetching sampling rates to the server
+     *
+     * @return JSONObject of sampling rates from server
+     */
+    static JSONObject fetchSamplingRate() {
+        Bundle monitorConfigParams = new Bundle();
+        monitorConfigParams.putString(APPLICATION_FIELDS, MONITOR_CONFIG);
+        GraphRequest request = GraphRequest.newGraphPathRequest(
+                null, FacebookSdk.getApplicationId(), null);
+        request.setSkipClientToken(true);
+        request.setParameters(monitorConfigParams);
+        return request.executeAndWait().getJSONObject();
+    }
+
+    /**
+     * update samplingRatesMap using fetched sampling rates
+     *
+     * @param fetchedSamplingRates
+     */
+    static void updateSamplingRateMap(JSONObject fetchedSamplingRates) {
+        try {
+            JSONArray samplingRates = fetchedSamplingRates
+                    .getJSONObject(MONITOR_CONFIG)
+                    .getJSONArray(SAMPLE_RATES);
+            for (int i = 0; i < samplingRates.length(); i++) {
+                JSONObject keyValuePair = samplingRates.getJSONObject(i);
+                String eventName = keyValuePair.getString("key");
+                int samplingRate = keyValuePair.getInt("value");
+                if (DEFAULT_SAMPLE_RATES_KEY.equals(eventName)) {
+                    defaultSamplingRate = samplingRate;
+                } else {
+                    samplingRatesMap.put(eventName, samplingRate);
+                }
+            }
+        } catch (JSONException e) {
+            // swallow Exception to avoid user's app to crash
+        }
+    }
+
+    /**
+     * add the log to the monitoring system if the log is sampled
+     *
+     * @param log which will be sent back to the server
+     */
+    public static void addLog(ExternalLog log) {
+        if (isEnabled && isSampled(log)) {
+            monitorLoggingManager.addLog(log);
+        }
+    }
+
+    public static boolean isEnabled() {
+        return isEnabled;
+    }
+
+    /**
+     * @return true if this log should be added respecting its sampling rate
+     */
+    static boolean isSampled(ExternalLog log) {
+        String eventName = log.getEventName();
+        int samplingRate = defaultSamplingRate;
+        if (samplingRatesMap.containsKey(eventName)) {
+            samplingRate = samplingRatesMap.get(eventName);
+        }
+        return samplingRate > 0 && random.nextInt(samplingRate) == 0;
+    }
+
+    // for cleaner test
+    static Integer getDefaultSamplingRate() {
+        return defaultSamplingRate;
+    }
+}

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
@@ -8,4 +8,9 @@ public class MonitorLogServerProtocol {
     public static final String PARAM_DEVICE_OS_VERSION = "device_os_version";
     public static final String PARAM_TIME_START = "time_start";
     public static final String PARAM_TIME_SPENT = "time_spent";
+
+    public static final String APPLICATION_FIELDS = "fields";
+    public static final String MONITOR_CONFIG = "monitoring_config";
+    public static final String SAMPLE_RATES = "sample_rates";
+    public static final String DEFAULT_SAMPLE_RATES_KEY = "default";
 }

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
@@ -1,3 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.facebook.internal.logging.monitor;
 
 import com.facebook.internal.logging.LogCategory;
@@ -15,6 +34,8 @@ public class MonitorLoggingTestUtil {
     static final int INVALID_TIME = -1;
     static final long INVALID_TIME_LONG = -1;
     static final LogEvent TEST_LOG_EVENT = new LogEvent(TEST_EVENT_NAME, TEST_CATEGORY);
+    static final int TEST_SAMPLING_RATE = 100;
+    static final Integer TEST_DEFAULT_SAMPLING_RATE = 20;
 
     public static MonitorLog getTestMonitorLog(long timeStart, int timeSpent) {
         MonitorLog log = new MonitorLog.LogBuilder(TEST_LOG_EVENT)

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * <p>
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+ * copy, modify, and distribute this software in source code or binary form for use
+ * in connection with the web services and APIs provided by Facebook.
+ * <p>
+ * As with any software that integrates with the Facebook platform, your use of
+ * this software is subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be
+ * included in all copies or substantial portions of the software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.facebook.internal.logging.monitor;
+
+import com.facebook.FacebookPowerMockTestCase;
+import com.facebook.FacebookSdk;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.util.ReflectionHelpers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_APP_ID;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_DEFAULT_SAMPLING_RATE;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_EVENT_NAME;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_SAMPLING_RATE;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_TIME_START;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+@PrepareForTest({
+        FacebookSdk.class,
+        Monitor.class,
+})
+public class MonitorTest extends FacebookPowerMockTestCase {
+
+    @Mock
+    private MonitorLoggingManager mockMonitorLoggingManager;
+    private MonitorLog monitorLog;
+
+    private static final Boolean mockIsEnabled = false;
+    private static final Map<String, Integer> mockSamplingRatesMap = new HashMap<>();
+
+    @Before
+    public void init() {
+        mockStatic(Monitor.class);
+        spy(FacebookSdk.class);
+        PowerMockito.when(FacebookSdk.isInitialized()).thenReturn(true);
+        PowerMockito.when(FacebookSdk.getApplicationContext()).thenReturn(
+                RuntimeEnvironment.application);
+        PowerMockito.when(FacebookSdk.getApplicationId()).thenReturn(TEST_APP_ID);
+
+        monitorLog = MonitorLoggingTestUtil.getTestMonitorLog(TEST_TIME_START);
+
+        spy(Monitor.class);
+        ReflectionHelpers.setStaticField(Monitor.class, "samplingRatesMap", mockSamplingRatesMap);
+        ReflectionHelpers.setStaticField(Monitor.class, "isEnabled", mockIsEnabled);
+        ReflectionHelpers.setStaticField(Monitor.class, "monitorLoggingManager", mockMonitorLoggingManager);
+    }
+
+    @Test
+    public void testEnable() {
+        Assert.assertFalse(Monitor.isEnabled());
+        Monitor.enable();
+
+        Assert.assertTrue(Monitor.isEnabled());
+        verify(mockMonitorLoggingManager).flushLoggingStore();
+
+        PowerMockito.verifyStatic();
+        Monitor.loadSamplingRatesMapAsync();
+    }
+
+    @Test
+    public void testUpdateSamplingRatesMap() throws JSONException {
+        Map<String, Integer> expectedSamplingRatesMap = new HashMap<>();
+        expectedSamplingRatesMap.put(TEST_EVENT_NAME, TEST_SAMPLING_RATE);
+
+        String mockResponse = "{\n" +
+                "  \"monitoring_config\": {\n" +
+                "    \"sample_rates\": [\n" +
+                "      {\n" +
+                "        \"key\": \"default\",\n" +
+                "        \"value\":" + TEST_DEFAULT_SAMPLING_RATE + "\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"key\": \"" + TEST_EVENT_NAME + "\",\n" +
+                "        \"value\":" + TEST_SAMPLING_RATE + "\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"id\": \"123456\"\n" +
+                "}";
+        JSONObject responseJSON = new JSONObject(mockResponse);
+        Map<String, Integer> mockSamplingRatesMap = new HashMap<>();
+        ReflectionHelpers.setStaticField(Monitor.class, "samplingRatesMap", mockSamplingRatesMap);
+        Integer mockDefaultSamplingRate = 10;
+        ReflectionHelpers.setStaticField(Monitor.class, "defaultSamplingRate", mockDefaultSamplingRate);
+        Monitor.updateSamplingRateMap(responseJSON);
+        Assert.assertEquals(expectedSamplingRatesMap, mockSamplingRatesMap);
+        Assert.assertEquals(TEST_DEFAULT_SAMPLING_RATE, Monitor.getDefaultSamplingRate());
+    }
+
+    @Test
+    public void testIsSampledForEventNotInSamplingRatesMap() {
+        Integer mockDefaultSamplingRate = 1;
+        ReflectionHelpers.setStaticField(Monitor.class, "defaultSamplingRate", mockDefaultSamplingRate);
+        Assert.assertTrue(Monitor.isSampled(monitorLog));
+    }
+
+    @Test
+    public void testAddLog() {
+        Monitor.enable();
+        Monitor.addLog(monitorLog);
+        verify(mockMonitorLoggingManager).addLog(monitorLog);
+    }
+}


### PR DESCRIPTION
Summary:
Added Monitor class
Monitor class is the entry point of the Monitoring System.
The usage of the Monitoring System will be:
```
// assign value of timeStart, timeSpent or the value want to be logged
LogEvent logEvent = new LogEvent("FB_CORE_STARTUP", LogCategory.PERFORMANCE);
MonitorLog log = new MonitorLog.LogBuilder(logEvent)
                .timeStart(timeStart)
                .timeSpent(timeSpent)
                .build();
Monitor.add(log);
```
Monitor needs to be enabled before using it to add log. Enable Monitor will fetch the sampling rates from FB server, send the logs in the disk and clean the disk. *Enable part will be added in the next diff.*

**Sampling rate** is an integer indicating that we will send one every x logs for a specific event name. We have a default sampling rate for all events which are not specified in the list.

Reviewed By: Mxiim

Differential Revision: D20903128

