### PR TITLE
Add monitorEnabled for AppSettings

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettings.java
+++ b/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettings.java
@@ -50,6 +50,7 @@ public final class FetchedAppSettings {
     private String sdkUpdateMessage;
     private JSONArray eventBindings;
     private boolean trackUninstallEnabled;
+    private boolean monitorEnabled;
     @Nullable private String rawAamRules;
     @Nullable private String suggestedEventsSetting;
     @Nullable private String restrictiveDataSetting;
@@ -69,6 +70,7 @@ public final class FetchedAppSettings {
                               JSONArray eventBindings,
                               String sdkUpdateMessage,
                               boolean trackUninstallEnabled,
+                              boolean monitorEnabled,
                               @Nullable String rawAamRules,
                               @Nullable String suggestedEventsSetting,
                               @Nullable String restrictiveDataSetting
@@ -88,6 +90,7 @@ public final class FetchedAppSettings {
         this.eventBindings = eventBindings;
         this.sdkUpdateMessage = sdkUpdateMessage;
         this.trackUninstallEnabled = trackUninstallEnabled;
+        this.monitorEnabled = monitorEnabled;
         this.rawAamRules = rawAamRules;
         this.suggestedEventsSetting = suggestedEventsSetting;
         this.restrictiveDataSetting = restrictiveDataSetting;
@@ -142,6 +145,10 @@ public final class FetchedAppSettings {
 
     public boolean getTrackUninstallEnabled() {
         return trackUninstallEnabled;
+    }
+
+    public boolean getMonitorEnabled() {
+        return monitorEnabled;
     }
 
     public String getSdkUpdateMessage() { return sdkUpdateMessage; }

--- a/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettingsManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettingsManager.java
@@ -93,6 +93,7 @@ public final class FetchedAppSettingsManager {
     private static final int IAP_AUTOMATIC_LOGGING_ENABLED_BITMASK_FIELD = 1 << 4;
     private static final int CODELESS_EVENTS_ENABLED_BITMASK_FIELD = 1 << 5;
     private static final int TRACK_UNINSTALL_ENABLED_BITMASK_FIELD = 1 << 8;
+    private static final int MONITOR_ENABLED_BITMASK_FIELD = 1 << 14;
     private static final String APP_SETTING_SMART_LOGIN_OPTIONS =
             "seamless_login";
     private static final String SMART_LOGIN_BOOKMARK_ICON_URL = "smart_login_bookmark_icon_url";
@@ -313,6 +314,8 @@ public final class FetchedAppSettingsManager {
                 (featureBitmask & CODELESS_EVENTS_ENABLED_BITMASK_FIELD) != 0;
         boolean trackUninstallEnabled =
                 (featureBitmask & TRACK_UNINSTALL_ENABLED_BITMASK_FIELD) != 0;
+        boolean monitorEnabled =
+                (featureBitmask & MONITOR_ENABLED_BITMASK_FIELD) != 0;
         JSONArray eventBindings = settingsJSON.optJSONArray(APP_SETTING_APP_EVENTS_EVENT_BINDINGS);
 
         unityEventBindings = eventBindings;
@@ -338,6 +341,7 @@ public final class FetchedAppSettingsManager {
                 eventBindings,
                 settingsJSON.optString(SDK_UPDATE_MESSAGE),
                 trackUninstallEnabled,
+                monitorEnabled,
                 settingsJSON.optString(APP_SETTING_APP_EVENTS_AAM_RULE),
                 settingsJSON.optString(SUGGESTED_EVENTS_SETTING),
                 settingsJSON.optString(APP_SETTING_RESTRICTIVE_EVENT_FILTER_FIELD)


### PR DESCRIPTION
Summary:
We are going to add a feature toggle for monitoring on Devsite - settings.

Added monitorEnabled in FetchedAppSettings, in order to fetch the user settings from endpoint in the future.

Reviewed By: dreamolight

Differential Revision: D21406421

