### PR TITLE
Change List to Collection in LoggingStore

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/LoggingCache.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LoggingCache.java
@@ -20,7 +20,7 @@
 
 package com.facebook.internal.logging;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  *  LoggingCache will store the logs in the memory temporarily,
@@ -36,7 +36,7 @@ public interface LoggingCache {
     /**
      *  @return true if the size of LoggingCache has reached the flush limit after adding new logs
      */
-    boolean addLogs(List<? extends ExternalLog> logs);
+    boolean addLogs(Collection<? extends ExternalLog> logs);
 
     boolean isEmpty();
 

--- a/facebook-core/src/main/java/com/facebook/internal/logging/LoggingStore.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LoggingStore.java
@@ -20,12 +20,12 @@
 
 package com.facebook.internal.logging;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  *  LoggingStore will read/write logs from/to the disk
  */
 public interface LoggingStore {
-    List<ExternalLog> readAndClearStore();
-    void saveLogsToDisk(List<ExternalLog> logs);
+    Collection<ExternalLog> readAndClearStore();
+    void saveLogsToDisk(Collection<ExternalLog> logs);
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -37,6 +37,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -138,7 +139,7 @@ public class MonitorLoggingManager implements LoggingManager {
     // will be called once the Monitor is enabled
     @Override
     public void flushLoggingStore() {
-        List<ExternalLog> logsReadFromStore = logStore.readAndClearStore();
+        Collection<ExternalLog> logsReadFromStore = logStore.readAndClearStore();
         logQueue.addLogs(logsReadFromStore);
         flushAndWait();
     }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
@@ -24,8 +24,8 @@ import com.facebook.internal.logging.ExternalLog;
 import com.facebook.internal.logging.LoggingCache;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
 
 public class MonitorLoggingQueue implements LoggingCache {
@@ -58,7 +58,7 @@ public class MonitorLoggingQueue implements LoggingCache {
      * @return true if the log queue's size has reached the flush limit after adding the new log
      */
     @Override
-    public boolean addLogs(List<? extends ExternalLog> logs) {
+    public boolean addLogs(Collection<? extends ExternalLog> logs) {
         if (logs != null) {
             logQueue.addAll(logs);
         }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingStore.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingStore.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * MonitorLoggingStore will read/write logs from/to the disk.
@@ -65,14 +65,14 @@ public class MonitorLoggingStore implements LoggingStore {
      * @return logs fetched from the disk
      */
     @Override
-    public List<ExternalLog> readAndClearStore() {
-        List<ExternalLog> logs = new ArrayList<>();
+    public Collection<ExternalLog> readAndClearStore() {
+        Collection<ExternalLog> logs = new ArrayList<>();
         Context context = FacebookSdk.getApplicationContext();
         ObjectInputStream ois = null;
         try {
             InputStream is = context.openFileInput(PERSISTED_LOGS_FILENAME);
             ois = new ObjectInputStream(new BufferedInputStream(is));
-            logs = (List<ExternalLog>) ois.readObject();
+            logs = (Collection<ExternalLog>) ois.readObject();
         } catch (Exception e) {
             // swallow Exception to avoid user's app to crash
         } finally {
@@ -89,10 +89,10 @@ public class MonitorLoggingStore implements LoggingStore {
 
     /**
      * We will delete the file if there is any exception thrown.
-     * @param logs List of Externallog which should be written into disk
+     * @param logs Collection of Externallog which should be written into disk
      */
     @Override
-    public void saveLogsToDisk(List<ExternalLog> logs) {
+    public void saveLogsToDisk(Collection<ExternalLog> logs) {
         ObjectOutputStream oos = null;
         Context context = FacebookSdk.getApplicationContext();
 

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingStoreTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingStoreTest.java
@@ -33,7 +33,8 @@ import org.powermock.reflect.Whitebox;
 import org.robolectric.RuntimeEnvironment;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.concurrent.Executor;
 
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_TIME_SPENT;
@@ -59,26 +60,31 @@ public class MonitorLoggingStoreTest extends FacebookPowerMockTestCase {
     public void testWriteAndReadFromStore() {
         MonitorLoggingStore logStore = MonitorLoggingStore.getInstance();
 
-        List<ExternalLog> firstLogsWriteToStore = new ArrayList<>();
+        Collection<ExternalLog> firstLogsWriteToStore = new ArrayList<>();
         MonitorLog log = MonitorLoggingTestUtil.getTestMonitorLog(TEST_TIME_START);
         firstLogsWriteToStore.add(log);
         logStore.saveLogsToDisk(firstLogsWriteToStore);
 
         // add logs after adding the first log list
         // to see if the first ones are erased
-        List<ExternalLog> secondLogsWriteToStore = new ArrayList<>();
+        Collection<ExternalLog> secondLogsWriteToStore = new ArrayList<>();
         for (int i = 0; i < LOGS_BATCH_NUMBER; i++) {
             log = MonitorLoggingTestUtil.getTestMonitorLog(TEST_TIME_START, TEST_TIME_SPENT);
             secondLogsWriteToStore.add(log);
         }
 
         logStore.saveLogsToDisk(secondLogsWriteToStore);
-        List<ExternalLog> logsReadFromStore = logStore.readAndClearStore();
+        Collection<ExternalLog> logsReadFromStore = logStore.readAndClearStore();
 
         // Logs read from store should only have the ones we added at second time
+        // compare the size
         Assert.assertEquals(secondLogsWriteToStore.size(), logsReadFromStore.size());
-        for (int i = 0; i < secondLogsWriteToStore.size(); i++) {
-            Assert.assertEquals(secondLogsWriteToStore.get(i), logsReadFromStore.get(i));
+
+        Iterator<ExternalLog> iteratorOfSecondLogsWriteToStore = secondLogsWriteToStore.iterator();
+        Iterator<ExternalLog> iteratorOfLogsReadFromStore = logsReadFromStore.iterator();
+
+        while (iteratorOfSecondLogsWriteToStore.hasNext() && iteratorOfLogsReadFromStore.hasNext()) {
+            Assert.assertEquals(iteratorOfSecondLogsWriteToStore.next(), iteratorOfLogsReadFromStore.next());
         }
 
         // make sure the file is deleted


### PR DESCRIPTION
Summary: Changed type List to Collection since we use LinkedList in MonitorLoggingQueue, change the input type from List to Collection will be easier to operate.

Reviewed By: Mxiim

Differential Revision: D21412768

