### PR TITLE
Add fetchAllLogs in LoggingCache

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/LoggingCache.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/LoggingCache.java
@@ -44,4 +44,9 @@ public interface LoggingCache {
      * fetch ExternalLog from LoggingCache
      */
     ExternalLog fetchLog();
+
+    /**
+     * fetch all ExternalLog from LoggingCache, and then empty the LoggingCache
+     */
+    Collection<ExternalLog> fetchAllLogs();
 }

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
@@ -82,4 +82,11 @@ public class MonitorLoggingQueue implements LoggingCache {
     public ExternalLog fetchLog() {
         return logQueue.poll();
     }
+
+    @Override
+    public Collection<ExternalLog> fetchAllLogs() {
+        Collection<ExternalLog> logs = new LinkedList<>(this.logQueue);
+        this.logQueue.clear();
+        return logs;
+    }
 }

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingQueueTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingQueueTest.java
@@ -15,6 +15,9 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.util.ReflectionHelpers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -70,6 +73,24 @@ public class MonitorLoggingQueueTest extends FacebookPowerMockTestCase {
         MonitorLog log = MonitorLoggingTestUtil.getTestMonitorLog(TEST_TIME_START);
         hasReachedFlushLimit = monitorLoggingQueue.addLog(log);
         Assert.assertTrue(hasReachedFlushLimit);
+    }
+
+    @Test
+    public void testFetchAllLogs() {
+        monitorLoggingQueue.addLog(testLog);
+        Collection expectedLogs = Arrays.asList(testLog);
+        Collection<ExternalLog> fetchedLogs = monitorLoggingQueue.fetchAllLogs();
+
+        // compare the size
+        Assert.assertEquals(expectedLogs.size(), fetchedLogs.size());
+
+        Iterator<ExternalLog> iteratorOfExpectedLogs = expectedLogs.iterator();
+        Iterator<ExternalLog> iteratorOfFetchedLogs = fetchedLogs.iterator();
+        while (iteratorOfExpectedLogs.hasNext() && iteratorOfFetchedLogs.hasNext()) {
+            Assert.assertEquals(iteratorOfExpectedLogs.next(), iteratorOfFetchedLogs.next());
+        }
+
+        Assert.assertTrue(monitorLoggingQueue.isEmpty());
     }
 
     // make sure we have emptied the monitor logging queue after each test


### PR DESCRIPTION
Summary: Adding `fetchAllLogs()`, it will return all logs in LoggingCache and clear it.

Reviewed By: Mxiim

Differential Revision: D21430826

