### PR TITLE
Catch RejectedExecutionException in schedule()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Handle RejectedExecutionException in ViewIndexer.schedule()
 
 ## [7.0.0] - 2020-05-05
 


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Add try catch for RejectedExecutionException thrown in ViewIndexer's getExcetutor().execute().
This exception may be thrown by Executor.execute() when maxPoolSize is reached.
Android app using the SDK may keep getting the crash but won't have a way to catch it.

## Test Plan

Test Plan: **Add your test plan here**
