### PR TITLE
Enable Monitor during SDK is initializing

### DIFF
--- a/facebook-core/src/main/java/com/facebook/FacebookSdk.java
+++ b/facebook-core/src/main/java/com/facebook/FacebookSdk.java
@@ -48,6 +48,7 @@ import com.facebook.internal.ServerProtocol;
 import com.facebook.internal.Utility;
 import com.facebook.internal.Validate;
 import com.facebook.internal.instrument.InstrumentManager;
+import com.facebook.internal.logging.monitor.MonitorManager;
 import java.io.File;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -132,6 +133,9 @@ public final class FacebookSdk {
 
   /** The key for the callback off set in the Android manifest. */
   public static final String CALLBACK_OFFSET_PROPERTY = "com.facebook.sdk.CallbackOffset";
+
+  /** The key for the monitor enable in the Android manifest. */
+  public static final String MONITOR_ENABLED_PROPERTY = "com.facebook.sdk.MonitorEnabled";
 
   private static Boolean sdkInitialized = false;
   private static Boolean sdkFullyInitialized = false;
@@ -350,6 +354,17 @@ public final class FacebookSdk {
           public void onCompleted(boolean enabled) {
             if (enabled) {
               ignoreAppSwitchToLoggedOut = true;
+            }
+          }
+        });
+
+    FeatureManager.checkFeature(
+        FeatureManager.Feature.Monitoring,
+        new FeatureManager.Callback() {
+          @Override
+          public void onCompleted(boolean enabled) {
+            if (enabled) {
+              MonitorManager.start();
             }
           }
         });
@@ -1002,6 +1017,24 @@ public final class FacebookSdk {
    */
   public static void setCodelessDebugLogEnabled(boolean flag) {
     codelessDebugLogEnabled = flag;
+  }
+
+  /**
+   * Gets the flag of Monitor Feature
+   *
+   * @return the monitor flag to indicate if it has been turn on
+   */
+  public static boolean getMonitorEnabled() {
+    return UserSettingsManager.getMonitorEnabled();
+  }
+
+  /**
+   * Sets the monitor flag for the application
+   *
+   * @param flag true or false
+   */
+  public static void setMonitorEnabled(boolean flag) {
+    UserSettingsManager.setMonitorEnabled(flag);
   }
 
   /**

--- a/facebook-core/src/main/java/com/facebook/UserSettingsManager.java
+++ b/facebook-core/src/main/java/com/facebook/UserSettingsManager.java
@@ -23,6 +23,7 @@ package com.facebook;
 import static com.facebook.FacebookSdk.ADVERTISER_ID_COLLECTION_ENABLED_PROPERTY;
 import static com.facebook.FacebookSdk.AUTO_INIT_ENABLED_PROPERTY;
 import static com.facebook.FacebookSdk.AUTO_LOG_APP_EVENTS_ENABLED_PROPERTY;
+import static com.facebook.FacebookSdk.MONITOR_ENABLED_PROPERTY;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -57,6 +58,9 @@ final class UserSettingsManager {
       new UserSetting(true, ADVERTISER_ID_COLLECTION_ENABLED_PROPERTY);
   private static UserSetting codelessSetupEnabled =
       new UserSetting(false, EVENTS_CODELESS_SETUP_ENABLED);
+
+  // Monitor enabled user setting from AndroidManifest
+  private static UserSetting MonitorEnabled = new UserSetting(true, MONITOR_ENABLED_PROPERTY);
 
   // Cache
   private static final String USER_SETTINGS = "com.facebook.sdk.USER_SETTINGS";
@@ -280,7 +284,8 @@ final class UserSettingsManager {
           String[] keys = {
             AUTO_INIT_ENABLED_PROPERTY,
             AUTO_LOG_APP_EVENTS_ENABLED_PROPERTY,
-            ADVERTISER_ID_COLLECTION_ENABLED_PROPERTY
+            ADVERTISER_ID_COLLECTION_ENABLED_PROPERTY,
+            MONITOR_ENABLED_PROPERTY
           };
           boolean[] defaultValues = {true, true, true};
           for (int i = 0; i < keys.length; i++) {
@@ -381,6 +386,21 @@ final class UserSettingsManager {
   public static boolean getCodelessSetupEnabled() {
     initializeIfNotInitialized();
     return codelessSetupEnabled.getValue();
+  }
+
+  public static void setMonitorEnabled(boolean flag) {
+    MonitorEnabled.value = flag;
+    MonitorEnabled.lastTS = System.currentTimeMillis();
+    if (isInitialized.get()) {
+      writeSettingToCache(MonitorEnabled);
+    } else {
+      initializeIfNotInitialized();
+    }
+  }
+
+  public static boolean getMonitorEnabled() {
+    initializeIfNotInitialized();
+    return MonitorEnabled.getValue();
   }
 
   private static class UserSetting {

--- a/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettings.java
+++ b/facebook-core/src/main/java/com/facebook/internal/FetchedAppSettings.java
@@ -48,7 +48,7 @@ public final class FetchedAppSettings {
   private String sdkUpdateMessage;
   private JSONArray eventBindings;
   private boolean trackUninstallEnabled;
-  private boolean monitorEnabled;
+  private boolean monitorViaDialogEnabled;
   @Nullable private String rawAamRules;
   @Nullable private String suggestedEventsSetting;
   @Nullable private String restrictiveDataSetting;
@@ -69,7 +69,7 @@ public final class FetchedAppSettings {
       JSONArray eventBindings,
       String sdkUpdateMessage,
       boolean trackUninstallEnabled,
-      boolean monitorEnabled,
+      boolean monitorViaDialogEnabled,
       @Nullable String rawAamRules,
       @Nullable String suggestedEventsSetting,
       @Nullable String restrictiveDataSetting) {
@@ -88,7 +88,7 @@ public final class FetchedAppSettings {
     this.eventBindings = eventBindings;
     this.sdkUpdateMessage = sdkUpdateMessage;
     this.trackUninstallEnabled = trackUninstallEnabled;
-    this.monitorEnabled = monitorEnabled;
+    this.monitorViaDialogEnabled = monitorViaDialogEnabled;
     this.rawAamRules = rawAamRules;
     this.suggestedEventsSetting = suggestedEventsSetting;
     this.restrictiveDataSetting = restrictiveDataSetting;
@@ -150,8 +150,8 @@ public final class FetchedAppSettings {
     return trackUninstallEnabled;
   }
 
-  public boolean getMonitorEnabled() {
-    return monitorEnabled;
+  public boolean getMonitorViaDialogEnabled() {
+    return monitorViaDialogEnabled;
   }
 
   public String getSdkUpdateMessage() {

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
@@ -59,13 +59,13 @@ public class Monitor {
    * Enable Monitor will fetch the sampling rates from the server and send the logs from
    * MonitorLoggingStore
    */
-  public static void enable() {
+  protected static void enable() {
     if (isEnabled) {
       return;
     }
     isEnabled = true;
 
-    // pull down the sampling rates, update samplingRatesMap
+    // Pull down the sampling rates, and update samplingRatesMap
     loadSamplingRatesMapAsync();
 
     // flush disk
@@ -73,7 +73,7 @@ public class Monitor {
   }
 
   /** fetch the sampling rates from the server and update SamplingRatesMap */
-  public static void loadSamplingRatesMapAsync() {
+  protected static void loadSamplingRatesMapAsync() {
     FacebookSdk.getExecutor()
         .execute(
             new Runnable() {

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorManager.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * <p>You are hereby granted a non-exclusive, worldwide, royalty-free license to use, copy, modify,
+ * and distribute this software in source code or binary form for use in connection with the web
+ * services and APIs provided by Facebook.
+ *
+ * <p>As with any software that integrates with the Facebook platform, your use of this software is
+ * subject to the Facebook Developer Principles and Policies
+ * [http://developers.facebook.com/policy/]. This copyright notice shall be included in all copies
+ * or substantial portions of the software.
+ *
+ * <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.facebook.internal.logging.monitor;
+
+import androidx.annotation.VisibleForTesting;
+import com.facebook.FacebookSdk;
+import com.facebook.internal.FetchedAppSettings;
+import com.facebook.internal.FetchedAppSettingsManager;
+
+// This MonitorManager manages the Monitoring Feature. It's different from MonitorLoggingManager.
+// It plays the same role as InstrumentManager, AppEventsManager, etc.
+// Using this name to keep consistent of naming specific feature manager file.
+public class MonitorManager {
+
+  /** Abstraction for testability. */
+  @VisibleForTesting
+  public interface MonitorCreator {
+    void enable();
+  }
+
+  private static MonitorCreator monitorCreator =
+      new MonitorCreator() {
+        @Override
+        public void enable() {
+          Monitor.enable();
+        }
+      };
+
+  /**
+   * Start Monitoring functionality.
+   *
+   * <p>Note that the function should be called after FacebookSdk is initialized. Otherwise,
+   * exception FacebookSdkNotInitializedException will be thrown when loading and sending crash
+   * reports.
+   */
+  public static void start() {
+    if (!FacebookSdk.getMonitorEnabled()) {
+      return;
+    }
+    String appId = FacebookSdk.getApplicationId();
+    FetchedAppSettings settings = FetchedAppSettingsManager.getAppSettingsWithoutQuery(appId);
+
+    if (settings != null && settings.getMonitorViaDialogEnabled()) {
+      monitorCreator.enable();
+    }
+  }
+
+  @VisibleForTesting
+  static void setMonitorCreator(MonitorCreator monitorCreator) {
+    MonitorManager.monitorCreator = monitorCreator;
+  }
+}

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // Unit Tests
     testImplementation "junit:junit:$junitVersion"
     testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'androidx.test:core:1.0.0'
 
     testImplementation "org.mockito:mockito-inline:2.26.0"
 

--- a/facebook/src/test/java/com/facebook/FacebookPowerMockTestCase.java
+++ b/facebook/src/test/java/com/facebook/FacebookPowerMockTestCase.java
@@ -51,7 +51,8 @@ import org.robolectric.shadows.ShadowLog;
   "org.xml.sax.*",
   "org.w3c.dom.*",
   "org.springframework.context.*",
-  "org.apache.log4j.*"
+  "org.apache.log4j.*",
+  "kotlin.test.*"
 })
 
 /**

--- a/facebook/src/test/kotlin/com/facebook/internal/logging/monitor/MonitorManagerTest.kt
+++ b/facebook/src/test/kotlin/com/facebook/internal/logging/monitor/MonitorManagerTest.kt
@@ -1,0 +1,89 @@
+package com.facebook.internal.logging.monitor
+
+import androidx.test.core.app.ApplicationProvider
+import com.facebook.FacebookPowerMockTestCase
+import com.facebook.FacebookSdk
+import com.facebook.internal.FetchedAppSettings
+import com.facebook.internal.FetchedAppSettingsManager
+import com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_APP_ID
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.powermock.api.mockito.PowerMockito.mock
+import org.powermock.api.mockito.PowerMockito.mockStatic
+import org.powermock.api.mockito.PowerMockito.`when` as whenCalled
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.reflect.Whitebox
+
+@PrepareForTest(FacebookSdk::class, FetchedAppSettingsManager::class)
+class MonitorManagerTest : FacebookPowerMockTestCase() {
+  private val mockExecutor = FacebookSerialExecutor()
+  private lateinit var mockMonitorCreator: MonitorManager.MonitorCreator
+  private lateinit var mockSettings: FetchedAppSettings
+
+  @Before
+  fun init() {
+    mockStatic(FacebookSdk::class.java)
+    whenCalled(FacebookSdk.isInitialized()).thenReturn(true)
+    Whitebox.setInternalState(FacebookSdk::class.java, "executor", mockExecutor)
+    Whitebox.setInternalState(FacebookSdk::class.java, "applicationId", TEST_APP_ID)
+    whenCalled(FacebookSdk.getApplicationContext()).thenReturn(
+        ApplicationProvider.getApplicationContext())
+    whenCalled(FacebookSdk.getApplicationId()).thenReturn(TEST_APP_ID)
+    mockMonitorCreator = mock(MonitorManager.MonitorCreator::class.java)
+    MonitorManager.setMonitorCreator(mockMonitorCreator)
+    mockSettings = mock(FetchedAppSettings::class.java)
+    mockStatic(FetchedAppSettingsManager::class.java)
+    whenCalled(FetchedAppSettingsManager.getAppSettingsWithoutQuery(TEST_APP_ID)).thenReturn(
+        mockSettings)
+  }
+
+  @Test
+  fun `test start monitor not enabled from manifest and app settings from dialog is null`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(false)
+    whenCalled(FetchedAppSettingsManager.getAppSettingsWithoutQuery(TEST_APP_ID)).thenReturn(null)
+    MonitorManager.start()
+    verify(mockMonitorCreator, never()).enable()
+  }
+
+  @Test
+  fun `test start monitor not enabled from manifest and not enabled from dialog`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(false)
+    whenCalled(mockSettings.monitorViaDialogEnabled).thenReturn(false)
+    MonitorManager.start()
+    verify(mockMonitorCreator, never()).enable()
+  }
+
+  @Test
+  fun `test start monitor not enabled from manifest and enabled from dialog`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(false)
+    whenCalled(mockSettings.monitorViaDialogEnabled).thenReturn(true)
+    MonitorManager.start()
+    verify(mockMonitorCreator, never()).enable()
+  }
+
+  @Test
+  fun `test start monitor enabled from manifest and app settings from dialog is null`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(true)
+    whenCalled(FetchedAppSettingsManager.getAppSettingsWithoutQuery(TEST_APP_ID)).thenReturn(null)
+    MonitorManager.start()
+    verify(mockMonitorCreator, never()).enable()
+  }
+
+  @Test
+  fun `test start monitor enabled from manifest and not enabled from dialog`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(true)
+    whenCalled(mockSettings.monitorViaDialogEnabled).thenReturn(false)
+    MonitorManager.start()
+    verify(mockMonitorCreator, never()).enable()
+  }
+
+  @Test
+  fun `test start monitor enabled from manifest and enabled from dialog`() {
+    whenCalled(FacebookSdk.getMonitorEnabled()).thenReturn(true)
+    whenCalled(mockSettings.monitorViaDialogEnabled).thenReturn(true)
+    MonitorManager.start()
+    verify(mockMonitorCreator).enable()
+  }
+}


### PR DESCRIPTION
Summary:
Added MonitorManager to control enable or not the Monitor
Change loadSamplingRatesMapAsync() from public to protected (allow test to access)
Enabled Monitor when SDK is initializing

The dev need to turn on the feature toggle on Dev site to enable Monitor Feature.
To support the EU consent, the dev can set MonitorEnabled to false in AndroidManifest and once they get user's consent call Facebook.setMonitorEnabled(true) to re-enable.

The default value of the flag MonitorEnabled in AndroidManifest is true.

Reviewed By: Mxiim

Differential Revision: D21506564

