### PR TITLE
Refactor Android SDK fuzzy test to make it work with Powermock 2

### DIFF
--- a/facebook/src/test/java/com/facebook/LoadAppSettingsFuzzyTest.java
+++ b/facebook/src/test/java/com/facebook/LoadAppSettingsFuzzyTest.java
@@ -50,10 +50,6 @@ public class LoadAppSettingsFuzzyTest extends FacebookFuzzyInputPowerMockTestCas
     return getParametersForJSONString(jsonString);
   }
 
-  public LoadAppSettingsFuzzyTest(String inputJson, String nameToReplace, String valueToReplace) {
-    super(inputJson, nameToReplace, valueToReplace);
-  }
-
   @Before
   public void before() {
     MockSharedPreference mockPreference = new MockSharedPreference();


### PR DESCRIPTION
Summary: Refactoring the way arguments passed to make the test work. Previously, calling anything from `org.json.*` made the test to fail.

Reviewed By: Mxiim

Differential Revision: D21694427

