### PR TITLE
MeasurePerformance in Monitor class

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
@@ -135,6 +135,10 @@ public class MonitorLog implements ExternalLog {
     }
   }
 
+  public boolean isValid() {
+    return timeStart >= 0 && timeSpent >= 0;
+  }
+
   @Override
   public String toString() {
     String format = ": %s";

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorLoggingTestUtil.java
@@ -37,6 +37,9 @@ public class MonitorLoggingTestUtil {
   static final int TEST_SAMPLING_RATE = 100;
   static final Integer TEST_DEFAULT_SAMPLING_RATE = 20;
 
+  static final PerformanceEventName TEST_PERFORMANCE_EVENT_NAME =
+      PerformanceEventName.EVENT_NAME_FOR_TEST_FIRST;
+
   public static MonitorLog getTestMonitorLog(long timeStart, int timeSpent) {
     MonitorLog log =
         new MonitorLog.LogBuilder(TEST_LOG_EVENT).timeStart(timeStart).timeSpent(timeSpent).build();

--- a/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorTest.java
+++ b/facebook/src/test/java/com/facebook/internal/logging/monitor/MonitorTest.java
@@ -23,8 +23,12 @@ package com.facebook.internal.logging.monitor;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_APP_ID;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_DEFAULT_SAMPLING_RATE;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_EVENT_NAME;
+import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_PERFORMANCE_EVENT_NAME;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_SAMPLING_RATE;
 import static com.facebook.internal.logging.monitor.MonitorLoggingTestUtil.TEST_TIME_START;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
@@ -139,5 +143,34 @@ public class MonitorTest extends FacebookPowerMockTestCase {
     Monitor.enable();
     Monitor.addLog(monitorLog);
     verify(mockMonitorLoggingManager).addLog(monitorLog);
+  }
+
+  @Test
+  public void testMeasurePerfFor() {
+    testMeasurePerfInit();
+    Monitor.startMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    Monitor.stopMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    verify(mockMonitorLoggingManager).addLog(any(MonitorLog.class));
+  }
+
+  @Test
+  public void testStopMeasurePerfForWithoutStartMeasurePerfFor() {
+    testMeasurePerfInit();
+    Monitor.stopMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    verify(mockMonitorLoggingManager, never()).addLog(any(MonitorLog.class));
+  }
+
+  @Test
+  public void testMultipleCallStartMeasurePerfFor() {
+    testMeasurePerfInit();
+    Monitor.startMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    Monitor.startMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    Monitor.stopMeasurePerfFor(TEST_PERFORMANCE_EVENT_NAME);
+    verify(mockMonitorLoggingManager, times(1)).addLog(any(MonitorLog.class));
+  }
+
+  static void testMeasurePerfInit() {
+    PowerMockito.when(Monitor.isSampled(any(MonitorLog.class))).thenReturn(true);
+    Monitor.enable();
   }
 }


### PR DESCRIPTION
Summary:
Add measure performance related methods in Monitor class to make the API easier to use.
The dev can use the methods directly to measure the performance and send them back to our server.

Reviewed By: Mxiim

Differential Revision: D22259453

