### PR TITLE
Add RestrictTo annotation

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
@@ -25,6 +25,7 @@ import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.MON
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.SAMPLE_RATES;
 
 import android.os.Bundle;
+import androidx.annotation.RestrictTo;
 import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
 import com.facebook.internal.logging.ExternalLog;
@@ -42,6 +43,7 @@ import org.json.JSONObject;
  * sampling rates from the server and flush the disk (send the logs to the server and clean the
  * disk).
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class Monitor {
   private static final Random random = new Random();
 

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLog.java
@@ -26,6 +26,7 @@ import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PAR
 import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PARAM_TIME_START;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import com.facebook.internal.logging.ExternalLog;
 import com.facebook.internal.logging.LogCategory;
 import com.facebook.internal.logging.LogEvent;
@@ -38,6 +39,7 @@ import org.json.JSONObject;
  * MonitorLog will be sent to the server via our Monitor. MonitorLog must have a Log Event including
  * a logCategory and an event name which indicates the specific tracked feature/function.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorLog implements ExternalLog {
 
   private static final long serialVersionUID = 1L;

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLogServerProtocol.java
@@ -1,5 +1,8 @@
 package com.facebook.internal.logging.monitor;
 
+import androidx.annotation.RestrictTo;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorLogServerProtocol {
   public static final String PARAM_EVENT_NAME = "event_name";
   public static final String PARAM_CATEGORY = "category";

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -26,6 +26,7 @@ import static com.facebook.internal.logging.monitor.MonitorLogServerProtocol.PAR
 
 import android.os.Build;
 import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
 import com.facebook.GraphRequestBatch;
@@ -55,6 +56,7 @@ import org.json.JSONObject;
  * <p>Each GraphRequest can have limited number of logs in the parameter in maximum. We send the
  * GraphRequest(s) using GraphRequestBatch call.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorLoggingManager implements LoggingManager {
   private static final int FLUSH_PERIOD = 60; // in second
   private static final Integer MAX_LOG_NUMBER_PER_REQUEST = 100;

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingQueue.java
@@ -20,6 +20,7 @@
 
 package com.facebook.internal.logging.monitor;
 
+import androidx.annotation.RestrictTo;
 import com.facebook.internal.logging.ExternalLog;
 import com.facebook.internal.logging.LoggingCache;
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Queue;
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorLoggingQueue implements LoggingCache {
   private static MonitorLoggingQueue monitorLoggingQueue;
   private Queue<ExternalLog> logQueue = new LinkedList<>();

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingStore.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingStore.java
@@ -21,6 +21,7 @@
 package com.facebook.internal.logging.monitor;
 
 import android.content.Context;
+import androidx.annotation.RestrictTo;
 import com.facebook.FacebookSdk;
 import com.facebook.internal.Utility;
 import com.facebook.internal.logging.ExternalLog;
@@ -43,6 +44,7 @@ import java.util.Collection;
  *
  * <p>We will fetch the logs in the disk and send them to the server once Monitor is enabled.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorLoggingStore implements LoggingStore {
   private static MonitorLoggingStore monitorLoggingStore;
   public static final String PERSISTED_LOGS_FILENAME = "facebooksdk.monitoring.persistedlogs";

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorManager.java
@@ -18,6 +18,7 @@
  */
 package com.facebook.internal.logging.monitor;
 
+import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.facebook.FacebookSdk;
 import com.facebook.internal.FetchedAppSettings;
@@ -26,6 +27,7 @@ import com.facebook.internal.FetchedAppSettingsManager;
 // This MonitorManager manages the Monitoring Feature. It's different from MonitorLoggingManager.
 // It plays the same role as InstrumentManager, AppEventsManager, etc.
 // Using this name to keep consistent of naming specific feature manager file.
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class MonitorManager {
 
   /** Abstraction for testability. */

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/PerformanceEventName.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/PerformanceEventName.java
@@ -1,5 +1,8 @@
 package com.facebook.internal.logging.monitor;
 
+import androidx.annotation.RestrictTo;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public enum PerformanceEventName {
   EVENT_NAME_FOR_TEST_FIRST("EVENT_NAME_FOR_TEST_FIRST"),
   EVENT_NAME_FOR_TEST_SECOND("EVENT_NAME_FOR_TEST_SECOND"),


### PR DESCRIPTION
Summary: Added `RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` to the monitoring system since it will be used inside the SDK.

Reviewed By: Mxiim

Differential Revision: D22440145

