### PR TITLE
Move MetricsUtil to monitor folder

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MetricsUtil.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MetricsUtil.java
@@ -17,15 +17,13 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.facebook.internal.metrics;
+package com.facebook.internal.logging.monitor;
 
 import android.os.SystemClock;
 import androidx.annotation.RestrictTo;
 import com.facebook.internal.Utility;
 import com.facebook.internal.logging.LogCategory;
 import com.facebook.internal.logging.LogEvent;
-import com.facebook.internal.logging.monitor.MonitorLog;
-import com.facebook.internal.logging.monitor.PerformanceEventName;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/Monitor.java
@@ -30,7 +30,6 @@ import com.facebook.FacebookSdk;
 import com.facebook.GraphRequest;
 import com.facebook.internal.logging.ExternalLog;
 import com.facebook.internal.logging.LoggingManager;
-import com.facebook.internal.metrics.MetricsUtil;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;

--- a/facebook/src/test/kotlin/com/facebook/internal/logging/monitor/MetricsUtilTest.kt
+++ b/facebook/src/test/kotlin/com/facebook/internal/logging/monitor/MetricsUtilTest.kt
@@ -1,12 +1,10 @@
-package com.facebook.internal.metrics
+package com.facebook.internal.logging.monitor
 
 import android.os.SystemClock as AndroidOsSystemClock
 import com.facebook.FacebookPowerMockTestCase
 import com.facebook.internal.logging.LogCategory
 import com.facebook.internal.logging.LogEvent
-import com.facebook.internal.logging.monitor.MonitorLog
-import com.facebook.internal.logging.monitor.PerformanceEventName
-import com.facebook.internal.metrics.MetricsUtil.INVALID_TIME
+import com.facebook.internal.logging.monitor.MetricsUtil.INVALID_TIME
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.Before


### PR DESCRIPTION
Summary:
MetricsUtil is for Monitoring system
Move MetricsUtil to monitor folder

Reviewed By: Mxiim

Differential Revision: D22506452

