### PR TITLE
Convert JsonArray to String in GraphObject

### DIFF
--- a/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
+++ b/facebook-core/src/main/java/com/facebook/internal/logging/monitor/MonitorLoggingManager.java
@@ -188,7 +188,7 @@ public class MonitorLoggingManager implements LoggingManager {
       params.put(PARAM_DEVICE_OS_VERSION, deviceOSVersion);
       params.put(PARAM_DEVICE_MODEL, deviceModel);
       params.put(PARAM_UNIQUE_APPLICATION_ID, packageName);
-      params.put(ENTRIES_KEY, logsToParams);
+      params.put(ENTRIES_KEY, logsToParams.toString());
     } catch (JSONException e) {
       return null;
     }


### PR DESCRIPTION
Summary:
The endpoint can not get the `entries` as a part of paramters if we pass JsonArray to GraphObject.
Convert JsonArray to String to fix it.

Reviewed By: jingping2015

Differential Revision: D22415163

