### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4g


### PR DESCRIPTION
Disable jetifier `android.enableJetifier=true` shouldn't be necessary, and will prevent introducing any unsupported libraries

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [ ] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
