### PR TITLE
Fix GamingMediaUploader callback when shouldOpenMediaDialog = false

### DIFF
--- a/facebook-gamingservices/src/main/java/com/facebook/gamingservices/GamingImageUploader.java
+++ b/facebook-gamingservices/src/main/java/com/facebook/gamingservices/GamingImageUploader.java
@@ -73,7 +73,7 @@ public class GamingImageUploader {
       boolean shouldLaunchMediaDialog,
       GraphRequest.Callback callback) {
     AccessToken accessToken = AccessToken.getCurrentAccessToken();
-    GraphRequest.Callback openMediaCallback = null;
+    GraphRequest.Callback openMediaCallback = callback;
     if (shouldLaunchMediaDialog) {
       openMediaCallback = new OpenGamingMediaDialog(this.context, callback);
     }
@@ -127,7 +127,7 @@ public class GamingImageUploader {
       GraphRequest.Callback callback)
       throws FileNotFoundException {
     AccessToken accessToken = AccessToken.getCurrentAccessToken();
-    GraphRequest.Callback openMediaCallback = null;
+    GraphRequest.Callback openMediaCallback = callback;
     if (shouldLaunchMediaDialog) {
       openMediaCallback = new OpenGamingMediaDialog(this.context, callback);
     }


### PR DESCRIPTION
Summary:
When shouldOpenMediaDialog = False
and a callback was passed it would silently be dropped. This fixes this bug.

Reviewed By: Mxiim

Differential Revision: D22798752

