### PR TITLE
Fix on example FBLoginExample

### DIFF
--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/MainActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/MainActivity.java
@@ -35,13 +35,12 @@ public class MainActivity extends Activity {
   private static final int RESULT_POSTS_ACTIVITY = 2;
   private static final int RESULT_PERMISSIONS_ACTIVITY = 3;
 
-  private static final String DEFAULT_FB_APP_ID = "ENTER_YOUR_FB_APP_ID_HERE";
-
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
-    if (getResources().getString(R.string.facebook_app_id).equals(DEFAULT_FB_APP_ID)) {
+    // string fb login protocol schema must contain "fb" + facebook app id.
+    if (!getResources().getString(R.string.fb_login_protocol_scheme).contains(getResources().getString(R.string.facebook_app_id))) {
       showAlertNoFacebookAppId();
       return;
     }


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [X] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)

## Pull Request Details

Initially when facebook_app_id (in activity) and facebook_app_id (in resource string) have the same value will display a warning, it should display a warning when fb_login_protocol_scheme does not contain facebook_app_id.
