### PR TITLE
Add NonNull annotation to FacebookCallback interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+- Added NonNull annotation to FacebookCallback interface
+
 ## [8.1.0] - 2020-10-13
 
 ## Changed

--- a/facebook-common/src/main/java/com/facebook/FacebookCallback.java
+++ b/facebook-common/src/main/java/com/facebook/FacebookCallback.java
@@ -19,6 +19,7 @@
  */
 
 package com.facebook;
+import androidx.annotation.NonNull;
 
 /** A callback class for the Facebook SDK. */
 public interface FacebookCallback<RESULT> {
@@ -35,7 +36,7 @@ public interface FacebookCallback<RESULT> {
    *
    * @param result Result from the dialog
    */
-  public void onSuccess(RESULT result);
+  public void onSuccess(@NonNull RESULT result);
 
   /**
    * Called when the dialog is canceled.
@@ -55,5 +56,5 @@ public interface FacebookCallback<RESULT> {
    *
    * @param error The error that occurred
    */
-  public void onError(FacebookException error);
+  public void onError(@NonNull FacebookException error);
 }

--- a/facebook/src/androidTest/java/com/facebook/RequestTests.java
+++ b/facebook/src/androidTest/java/com/facebook/RequestTests.java
@@ -25,6 +25,7 @@ import android.location.Location;
 import android.net.Uri;
 import android.os.Bundle;
 import android.test.suitebuilder.annotation.LargeTest;
+import androidx.annotation.NonNull;
 import com.facebook.internal.GraphUtil;
 import com.facebook.share.ShareApi;
 import com.facebook.share.Sharer;
@@ -254,7 +255,7 @@ public class RequestTests extends FacebookTestCase {
                 shareApi.share(
                     new FacebookCallback<Sharer.Result>() {
                       @Override
-                      public void onSuccess(Sharer.Result result) {
+                      public void onSuccess(@NonNull Sharer.Result result) {
                         actionId.set(result.getPostId());
                         notifyShareFinished();
                       }
@@ -265,7 +266,7 @@ public class RequestTests extends FacebookTestCase {
                       }
 
                       @Override
-                      public void onError(FacebookException error) {
+                      public void onError(@NonNull FacebookException error) {
                         notifyShareFinished();
                       }
 
@@ -317,7 +318,7 @@ public class RequestTests extends FacebookTestCase {
                 shareApi.share(
                     new FacebookCallback<Sharer.Result>() {
                       @Override
-                      public void onSuccess(Sharer.Result result) {
+                      public void onSuccess(@NonNull Sharer.Result result) {
                         actionId.set(result.getPostId());
                         notifyShareFinished();
                       }
@@ -328,7 +329,7 @@ public class RequestTests extends FacebookTestCase {
                       }
 
                       @Override
-                      public void onError(FacebookException error) {
+                      public void onError(@NonNull FacebookException error) {
                         errorOccurred.set(true);
                         notifyShareFinished();
                       }
@@ -575,7 +576,7 @@ public class RequestTests extends FacebookTestCase {
                 shareApi.share(
                     new FacebookCallback<Sharer.Result>() {
                       @Override
-                      public void onSuccess(Sharer.Result result) {
+                      public void onSuccess(@NonNull Sharer.Result result) {
                         imageId.set(result.getPostId());
                         notifyShareFinished();
                       }
@@ -586,7 +587,7 @@ public class RequestTests extends FacebookTestCase {
                       }
 
                       @Override
-                      public void onError(FacebookException error) {
+                      public void onError(@NonNull FacebookException error) {
                         notifyShareFinished();
                       }
 
@@ -641,7 +642,7 @@ public class RequestTests extends FacebookTestCase {
                   shareApi.share(
                       new FacebookCallback<Sharer.Result>() {
                         @Override
-                        public void onSuccess(Sharer.Result result) {
+                        public void onSuccess(@NonNull Sharer.Result result) {
                           videoId.set(result.getPostId());
                           notifyShareFinished();
                         }
@@ -652,7 +653,7 @@ public class RequestTests extends FacebookTestCase {
                         }
 
                         @Override
-                        public void onError(FacebookException error) {
+                        public void onError(@NonNull FacebookException error) {
                           notifyShareFinished();
                         }
 
@@ -704,7 +705,7 @@ public class RequestTests extends FacebookTestCase {
                   shareApi.share(
                       new FacebookCallback<Sharer.Result>() {
                         @Override
-                        public void onSuccess(Sharer.Result result) {
+                        public void onSuccess(@NonNull Sharer.Result result) {
                           videoId.set(result.getPostId());
                           notifyShareFinished();
                         }
@@ -715,7 +716,7 @@ public class RequestTests extends FacebookTestCase {
                         }
 
                         @Override
-                        public void onError(FacebookException error) {
+                        public void onError(@NonNull FacebookException error) {
                           notifyShareFinished();
                         }
 

--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/FacebookLoginActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/FacebookLoginActivity.java
@@ -23,6 +23,7 @@ package com.facebook.fbloginsample;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import androidx.annotation.NonNull;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -61,7 +62,7 @@ public class FacebookLoginActivity extends Activity {
         mCallbackManager,
         new FacebookCallback<LoginResult>() {
           @Override
-          public void onSuccess(LoginResult loginResult) {
+          public void onSuccess(@NonNull LoginResult loginResult) {
             setResult(RESULT_OK);
             finish();
           }
@@ -73,7 +74,7 @@ public class FacebookLoginActivity extends Activity {
           }
 
           @Override
-          public void onError(FacebookException e) {
+          public void onError(@NonNull FacebookException e) {
             // Handle exception
           }
         });

--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/PermissionsActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/PermissionsActivity.java
@@ -26,6 +26,7 @@ import android.os.Bundle;
 import android.widget.CompoundButton;
 import android.widget.Switch;
 import android.widget.Toast;
+import androidx.annotation.NonNull;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
@@ -165,7 +166,7 @@ public class PermissionsActivity extends Activity
 
   // Facebook Login Callbacks
   @Override
-  public void onSuccess(LoginResult loginResult) {
+  public void onSuccess(@NonNull LoginResult loginResult) {
     // Refresh token cached on device after login succeeds
     AccessToken.refreshCurrentAccessTokenAsync(this);
   }
@@ -176,7 +177,7 @@ public class PermissionsActivity extends Activity
   }
 
   @Override
-  public void onError(FacebookException error) {
+  public void onError(@NonNull FacebookException error) {
     // Handle exception ...
   }
 

--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/PostFeedActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/PostFeedActivity.java
@@ -29,6 +29,7 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
@@ -145,7 +146,7 @@ public class PostFeedActivity extends Activity
 
   // From FacebookLogin
   @Override
-  public void onSuccess(LoginResult loginResult) {
+  public void onSuccess(@NonNull LoginResult loginResult) {
     // Refresh token cached on device after login succeeds
     AccessToken.refreshCurrentAccessTokenAsync(this);
   }
@@ -156,7 +157,7 @@ public class PostFeedActivity extends Activity
   }
 
   @Override
-  public void onError(FacebookException e) {
+  public void onError(@NonNull FacebookException e) {
     // Handle exception ...
   }
 

--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/callbacks/PublishPostCallback.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/callbacks/PublishPostCallback.java
@@ -20,6 +20,7 @@
 
 package com.facebook.fbloginsample.callbacks;
 
+import androidx.annotation.NonNull;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
 import com.facebook.GraphRequest;
@@ -50,7 +51,7 @@ public class PublishPostCallback {
     mShareCallback =
         new FacebookCallback<Sharer.Result>() {
           @Override
-          public void onSuccess(Sharer.Result result) {
+          public void onSuccess(@NonNull Sharer.Result result) {
             // Handled by PostFeedActivity
             caller.onPublishCompleted();
           }
@@ -61,7 +62,7 @@ public class PublishPostCallback {
           }
 
           @Override
-          public void onError(FacebookException error) {
+          public void onError(@NonNull FacebookException error) {
             // Handle exception ...
           }
         };

--- a/samples/HelloFacebookSample/src/com/example/hellofacebook/HelloFacebookSampleActivity.java
+++ b/samples/HelloFacebookSample/src/com/example/hellofacebook/HelloFacebookSampleActivity.java
@@ -31,6 +31,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
 import com.facebook.*;
 import com.facebook.AccessToken;
@@ -79,7 +80,7 @@ public class HelloFacebookSampleActivity extends FragmentActivity {
         }
 
         @Override
-        public void onError(FacebookException error) {
+        public void onError(@NonNull FacebookException error) {
           Log.d("HelloFacebook", String.format("Error: %s", error.toString()));
           String title = getString(R.string.error);
           String alertMessage = error.getMessage();
@@ -87,7 +88,7 @@ public class HelloFacebookSampleActivity extends FragmentActivity {
         }
 
         @Override
-        public void onSuccess(Sharer.Result result) {
+        public void onSuccess(@NonNull Sharer.Result result) {
           Log.d("HelloFacebook", "Success!");
           if (result.getPostId() != null) {
             String title = getString(R.string.success);
@@ -123,7 +124,7 @@ public class HelloFacebookSampleActivity extends FragmentActivity {
             callbackManager,
             new FacebookCallback<LoginResult>() {
               @Override
-              public void onSuccess(LoginResult loginResult) {
+              public void onSuccess(@NonNull LoginResult loginResult) {
                 handlePendingAction();
                 updateUI();
               }
@@ -138,7 +139,7 @@ public class HelloFacebookSampleActivity extends FragmentActivity {
               }
 
               @Override
-              public void onError(FacebookException exception) {
+              public void onError(@NonNull FacebookException exception) {
                 if (pendingAction != PendingAction.NONE
                     && exception instanceof FacebookAuthorizationException) {
                   showAlert();

--- a/samples/PlacesGraphSample/src/com/example/places/fragments/LoginFragment.java
+++ b/samples/PlacesGraphSample/src/com/example/places/fragments/LoginFragment.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.example.places.R;
@@ -104,7 +105,7 @@ public class LoginFragment extends Fragment {
         callbackManager,
         new FacebookCallback<LoginResult>() {
           @Override
-          public void onSuccess(LoginResult loginResult) {
+          public void onSuccess(@NonNull LoginResult loginResult) {
             listener.onLoginComplete();
           }
 
@@ -115,7 +116,7 @@ public class LoginFragment extends Fragment {
           }
 
           @Override
-          public void onError(FacebookException exception) {
+          public void onError(@NonNull FacebookException exception) {
             Log.d(TAG, "onError: " + exception);
             showAlert();
           }

--- a/samples/RPSSample/src/com/example/rps/MainActivity.java
+++ b/samples/RPSSample/src/com/example/rps/MainActivity.java
@@ -28,6 +28,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -135,12 +136,12 @@ public class MainActivity extends AppCompatActivity {
           }
 
           @Override
-          public void onError(FacebookException error) {
+          public void onError(@NonNull FacebookException error) {
             Log.d(TAG, String.format("Error: %s", error.toString()));
           }
 
           @Override
-          public void onSuccess(GameRequestDialog.Result result) {
+          public void onSuccess(@NonNull GameRequestDialog.Result result) {
             Log.d(TAG, "Success!");
             Log.d(TAG, "Request id: " + result.getRequestId());
             Log.d(TAG, "Recipients:");

--- a/samples/RPSSample/src/com/example/rps/RpsFragment.java
+++ b/samples/RPSSample/src/com/example/rps/RpsFragment.java
@@ -44,6 +44,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.android.vending.billing.IInAppBillingService;
 import com.facebook.*;
@@ -349,7 +350,7 @@ public class RpsFragment extends Fragment {
           content,
           new FacebookCallback<Sharer.Result>() {
             @Override
-            public void onSuccess(Sharer.Result result) {
+            public void onSuccess(@NonNull Sharer.Result result) {
               Log.i(TAG, "Posted OG Action with id: " + result.getPostId());
             }
 
@@ -359,7 +360,7 @@ public class RpsFragment extends Fragment {
             }
 
             @Override
-            public void onError(FacebookException error) {
+            public void onError(@NonNull FacebookException error) {
               Log.e(TAG, "Play action creation failed: " + error.getMessage());
             }
           });
@@ -644,7 +645,7 @@ public class RpsFragment extends Fragment {
             callbackManager,
             new FacebookCallback<LoginResult>() {
               @Override
-              public void onSuccess(LoginResult loginResult) {
+              public void onSuccess(@NonNull LoginResult loginResult) {
                 AccessToken accessToken = AccessToken.getCurrentAccessToken();
                 if (accessToken.getPermissions().contains(ADDITIONAL_PERMISSIONS)) {
                   publishResult();
@@ -659,7 +660,7 @@ public class RpsFragment extends Fragment {
               }
 
               @Override
-              public void onError(FacebookException exception) {
+              public void onError(@NonNull FacebookException exception) {
                 handleError();
               }
 
@@ -679,12 +680,12 @@ public class RpsFragment extends Fragment {
           }
 
           @Override
-          public void onError(FacebookException error) {
+          public void onError(@NonNull FacebookException error) {
             Log.d(TAG, String.format("Error: %s", error.toString()));
           }
 
           @Override
-          public void onSuccess(Sharer.Result result) {
+          public void onSuccess(@NonNull Sharer.Result result) {
             Log.d(TAG, "Success!");
           }
         };
@@ -696,7 +697,7 @@ public class RpsFragment extends Fragment {
     FacebookCallback<AppInviteDialog.Result> appInviteCallback =
         new FacebookCallback<AppInviteDialog.Result>() {
           @Override
-          public void onSuccess(AppInviteDialog.Result result) {
+          public void onSuccess(@NonNull AppInviteDialog.Result result) {
             Log.d(TAG, "Success!");
           }
 
@@ -706,7 +707,7 @@ public class RpsFragment extends Fragment {
           }
 
           @Override
-          public void onError(FacebookException error) {
+          public void onError(@NonNull FacebookException error) {
             Log.d(TAG, String.format("Error: %s", error.toString()));
           }
         };

--- a/samples/SwitchUserSample/src/com/example/switchuser/SettingsFragment.java
+++ b/samples/SwitchUserSample/src/com/example/switchuser/SettingsFragment.java
@@ -27,6 +27,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.view.*;
 import android.widget.*;
+import androidx.annotation.NonNull;
 import androidx.fragment.app.ListFragment;
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
@@ -89,12 +90,12 @@ public class SettingsFragment extends ListFragment {
         callbackManager,
         new FacebookCallback<LoginResult>() {
           @Override
-          public void onSuccess(LoginResult loginResult) {
+          public void onSuccess(@NonNull LoginResult loginResult) {
             Profile.fetchProfileForCurrentAccessToken();
           }
 
           @Override
-          public void onError(FacebookException exception) {
+          public void onError(@NonNull FacebookException exception) {
             AccessToken.setCurrentAccessToken(null);
             currentUserChanged();
           }


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

I added NonNull annotation to FacebookCallback interface.
Linters/IDEs use it to warn/error on usage with null argument.
It makes easier for Kotlin clients to implement this interface. 
