### PR TITLE
Add HashUtilsTest.kt unit test

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/internal/HashUtils.java
+++ b/facebook-core/src/main/java/com/facebook/appevents/internal/HashUtils.java
@@ -2,9 +2,6 @@
 
 package com.facebook.appevents.internal;
 
-import androidx.annotation.Nullable;
-import com.facebook.internal.qualityvalidation.Excuse;
-import com.facebook.internal.qualityvalidation.ExcusesForDesignViolations;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -13,16 +10,13 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 
 /** Utility class to compute file checksums. */
-@ExcusesForDesignViolations(@Excuse(type = "MISSING_UNIT_TEST", reason = "Legacy"))
 final class HashUtils {
   private static final String MD5 = "MD5";
 
-  @Nullable
   public static final String computeChecksum(String path) throws Exception {
     return computeFileMd5(new File(path));
   }
 
-  @Nullable
   private static String computeFileMd5(File file) throws Exception {
     final int BUFFER_SIZE = 1024;
     try (InputStream fis = new BufferedInputStream(new FileInputStream(file), BUFFER_SIZE)) {

--- a/facebook/src/test/kotlin/com/facebook/appevents/codeless/internal/EventBindingTest.kt
+++ b/facebook/src/test/kotlin/com/facebook/appevents/codeless/internal/EventBindingTest.kt
@@ -15,12 +15,12 @@
 package com.facebook.appevents.codeless.internal
 
 import com.facebook.FacebookPowerMockTestCase
+import com.facebook.util.common.assertThrows
 import java.util.*
 import kotlin.collections.ArrayList
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -176,18 +176,5 @@ class EventBindingTest : FacebookPowerMockTestCase() {
     val invalidSampleJson = JSONArray(invalidSampleArray3)
     val eventBindingList = EventBinding.parseArray(invalidSampleJson)
     assertEquals(emptyEventBindingList, eventBindingList)
-  }
-
-  private inline fun <reified T : Exception> assertThrows(runnable: () -> Any?) {
-    try {
-      runnable.invoke()
-    } catch (e: Throwable) {
-      if (e is T) {
-        return
-      }
-      Assert.fail(
-          "expected ${T::class.qualifiedName} but caught " + "${e::class.qualifiedName} instead")
-    }
-    Assert.fail("expected ${T::class.qualifiedName}")
   }
 }

--- a/facebook/src/test/kotlin/com/facebook/appevents/internal/HashUtilsTest.kt
+++ b/facebook/src/test/kotlin/com/facebook/appevents/internal/HashUtilsTest.kt
@@ -1,0 +1,37 @@
+package com.facebook.appevents.internal
+
+import com.facebook.FacebookPowerMockTestCase
+import com.facebook.util.common.assertThrows
+import java.io.File
+import java.io.FileNotFoundException
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HashUtilsTest : FacebookPowerMockTestCase() {
+
+  @Test
+  fun `test computeChecksum with non-empty file`() {
+    val tempFile = File.createTempFile("tempFile.txt", null)
+    tempFile.writeText("Hello World!")
+    tempFile.deleteOnExit()
+
+    val expectedChecksum = "ed076287532e86365e841e92bfc50d8c"
+    val actualChecksum = HashUtils.computeChecksum(tempFile.path)
+    assertEquals(expectedChecksum, actualChecksum)
+  }
+
+  @Test
+  fun `test computeChecksum with empty file`() {
+    val tempFile = File.createTempFile("tempFile.txt", null)
+    tempFile.deleteOnExit()
+
+    val emptyFileChecksum = "d41d8cd98f00b204e9800998ecf8427e"
+    val actualChecksum = HashUtils.computeChecksum(tempFile.path)
+    assertEquals(emptyFileChecksum, actualChecksum)
+  }
+
+  @Test
+  fun `test computeChecksum with missing file throws exception`() {
+    assertThrows<FileNotFoundException> { HashUtils.computeChecksum("/does/not/exist.txt") }
+  }
+}

--- a/facebook/src/test/kotlin/com/facebook/util/common/TestHelpers.kt
+++ b/facebook/src/test/kotlin/com/facebook/util/common/TestHelpers.kt
@@ -1,0 +1,16 @@
+package com.facebook.util.common
+
+import org.junit.Assert
+
+inline fun <reified T : Exception> assertThrows(runnable: () -> Any?) {
+  try {
+    runnable.invoke()
+  } catch (e: Throwable) {
+    if (e is T) {
+      return
+    }
+    Assert.fail(
+        "expected ${T::class.qualifiedName} but caught " + "${e::class.qualifiedName} instead")
+  }
+  Assert.fail("expected ${T::class.qualifiedName}")
+}


### PR DESCRIPTION
Summary:
Added a test for appevents.internal.HashUtils.java

Also:
- Removed Nullable due to warning: Nullable method 'computeFileMd5' always returns a non-null value
- Moved the assertThrows helper from EventBindingTest.kt into a util/common/TestHelpers.kt file

Reviewed By: Mxiim

Differential Revision: D24908731

