### PR TITLE
add timeout for fuzzy testing

### DIFF
--- a/facebook/src/test/java/com/facebook/FacebookFuzzyInputPowerMockTestCase.java
+++ b/facebook/src/test/java/com/facebook/FacebookFuzzyInputPowerMockTestCase.java
@@ -140,7 +140,7 @@ public abstract class FacebookFuzzyInputPowerMockTestCase extends FacebookPowerM
     return false;
   }
 
-  @Test
+  @Test(timeout = 120000) // 2min
   public void testGenFuzzy() {
     // Values for replacement. Variety of different types to try to catch some edge case.
     List<Object> possibleValues =


### PR DESCRIPTION
Summary:
this sometimes take very long time (i saw it with github actions), the current workaround is to just ignore it locally, so better add timeout.
Additionally, it only tests FetchedAppSettingsManager as of now, and we already added test for that.

Differential Revision: D24925690

