### PR TITLE
exclude a test from running on gh actions

### DIFF
--- a/.github/workflows/verifybuild.yml
+++ b/.github/workflows/verifybuild.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Assemble and test all
-        run: ./gradlew assemble && ./gradlew :facebook:test -i
+        run: ./gradlew assemble && GITHUB_ACTIONS=1 ./gradlew :facebook:test -i

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -95,7 +95,6 @@ android {
 
     sourceSets {
         test.java.srcDirs += 'src/test/kotlin'
-
         test {
             java {
                 exclude '**/MonitorTest.java'
@@ -103,9 +102,14 @@ android {
                 exclude '**/AppEventsLoggerImplTest.java'
                 exclude '**/UserSettingsManagerTest.java'
                 exclude '**/LoginManagerTest.java'
+                
+                if (System.getenv("GITHUB_ACTIONS") == "1") {
+                    exclude '**/OnDeviceProcessingManagerTest.java'
+                }
             }
         }
     }
+    
     
     if (System.getenv("SANDCASTLE") == "1") {
         testOptions {


### PR DESCRIPTION
Summary:
the test seems flaky on gh actions only, buck stress testing works, and so does sandcastle with gradle

I tried increasing timeouts, but still see issues on gh, decide to exclude to unblock the queue signal of build

Differential Revision: D25126563

