### PR TITLE
Move android sdk test to use binary resources

### DIFF
--- a/facebook/src/test/java/com/facebook/FacebookTestCase.java
+++ b/facebook/src/test/java/com/facebook/FacebookTestCase.java
@@ -30,7 +30,6 @@ import org.robolectric.shadows.ShadowLog;
 // ShadowLog is used to redirect the android.util.Log calls to System.out
 @Config(
     shadows = {ShadowLog.class},
-    manifest = "src/test/AndroidManifest.xml",
     sdk = 21)
 @RunWith(RobolectricTestRunner.class)
 


### PR DESCRIPTION
Summary: Legacy resources are deprecated. The manifest can no longer be loaded as it is created as part of the binary resources creation, so remove that config line. The gradle tests seem to pass still so seems fine.

Reviewed By: Mxiim

Differential Revision: D25819373

