### PR TITLE
Mock LocalBroadcastManager to avoid unexpected testing errors

### DIFF
--- a/facebook/src/test/java/com/facebook/AccessTokenManagerTest.java
+++ b/facebook/src/test/java/com/facebook/AccessTokenManagerTest.java
@@ -20,6 +20,7 @@
 
 package com.facebook;
 
+import static com.facebook.util.common.TestHelpersKt.mockLocalBroadcastManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -75,8 +76,8 @@ public class AccessTokenManagerTest extends FacebookPowerMockTestCase {
     when(FacebookSdk.getApplicationContext()).thenReturn(RuntimeEnvironment.application);
     suppress(method(Utility.class, "clearFacebookCookies"));
 
-    localBroadcastManager = LocalBroadcastManager.getInstance(RuntimeEnvironment.application);
     accessTokenCache = mock(AccessTokenCache.class);
+    localBroadcastManager = mockLocalBroadcastManager();
   }
 
   @Test

--- a/facebook/src/test/java/com/facebook/AccessTokenTrackerTest.java
+++ b/facebook/src/test/java/com/facebook/AccessTokenTrackerTest.java
@@ -20,8 +20,9 @@
 
 package com.facebook;
 
+import static com.facebook.util.common.TestHelpersKt.mockLocalBroadcastManager;
 import static org.junit.Assert.*;
-import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
@@ -40,7 +41,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.LooperMode;
 
 @LooperMode(LEGACY)
-@PrepareForTest({FacebookSdk.class})
+@PrepareForTest({FacebookSdk.class, LocalBroadcastManager.class})
 public class AccessTokenTrackerTest extends FacebookPowerMockTestCase {
 
   private final List<String> PERMISSIONS = Arrays.asList("walk", "chew gum");
@@ -50,19 +51,22 @@ public class AccessTokenTrackerTest extends FacebookPowerMockTestCase {
   private final String APP_ID = "1234";
   private final String USER_ID = "1000";
 
-  private LocalBroadcastManager localBroadcastManager;
   private TestAccessTokenTracker accessTokenTracker = null;
+  private LocalBroadcastManager localBroadcastManager;
 
   private final Executor mockExecutor = new FacebookSerialExecutor();
 
   @Before
   public void before() throws Exception {
-    spy(FacebookSdk.class);
+    mockStatic(FacebookSdk.class);
     when(FacebookSdk.isInitialized()).thenReturn(true);
     when(FacebookSdk.getApplicationContext()).thenReturn(RuntimeEnvironment.application);
     Whitebox.setInternalState(FacebookSdk.class, "executor", mockExecutor);
 
-    localBroadcastManager = LocalBroadcastManager.getInstance(RuntimeEnvironment.application);
+    localBroadcastManager = mockLocalBroadcastManager();
+    mockStatic(LocalBroadcastManager.class);
+    when(LocalBroadcastManager.getInstance(FacebookSdk.getApplicationContext()))
+        .thenReturn(localBroadcastManager);
   }
 
   @After

--- a/facebook/src/test/java/com/facebook/GraphErrorTest.java
+++ b/facebook/src/test/java/com/facebook/GraphErrorTest.java
@@ -28,6 +28,7 @@ import static org.powermock.api.support.membermodification.MemberMatcher.method;
 import static org.powermock.api.support.membermodification.MemberModifier.stub;
 import static org.powermock.api.support.membermodification.MemberModifier.suppress;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.facebook.internal.FacebookRequestErrorClassification;
 import com.facebook.internal.FetchedAppGateKeepersManager;
 import com.facebook.internal.Utility;
@@ -49,6 +50,7 @@ import org.robolectric.RuntimeEnvironment;
   FetchedAppGateKeepersManager.class,
   GraphRequest.class,
   Utility.class,
+  LocalBroadcastManager.class
 })
 public final class GraphErrorTest extends FacebookPowerMockTestCase {
 
@@ -60,6 +62,11 @@ public final class GraphErrorTest extends FacebookPowerMockTestCase {
         FacebookSdk.class, "applicationContext", RuntimeEnvironment.application);
     stub(method(AccessTokenCache.class, "save")).toReturn(null);
     mockStatic(FetchedAppGateKeepersManager.class);
+
+    LocalBroadcastManager mockLocalBroadcastManager = mock(LocalBroadcastManager.class);
+    mockStatic(LocalBroadcastManager.class);
+    when(LocalBroadcastManager.getInstance(FacebookSdk.getApplicationContext()))
+        .thenReturn(mockLocalBroadcastManager);
   }
 
   @Test

--- a/facebook/src/test/java/com/facebook/ProfileTest.java
+++ b/facebook/src/test/java/com/facebook/ProfileTest.java
@@ -22,16 +22,18 @@ package com.facebook;
 
 import static org.junit.Assert.*;
 
+import android.content.Context;
 import android.net.Uri;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.test.core.app.ApplicationProvider;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.robolectric.RuntimeEnvironment;
 
-@PrepareForTest(FacebookSdk.class)
+@PrepareForTest({FacebookSdk.class, LocalBroadcastManager.class})
 public final class ProfileTest extends FacebookPowerMockTestCase {
   static final String ID = "ID";
   static final String ANOTHER_ID = "ANOTHER_ID";
@@ -73,6 +75,11 @@ public final class ProfileTest extends FacebookPowerMockTestCase {
     PowerMockito.when(FacebookSdk.getApplicationId()).thenReturn("123456789");
     PowerMockito.when(FacebookSdk.getApplicationContext())
         .thenReturn(ApplicationProvider.getApplicationContext());
+    PowerMockito.mockStatic(LocalBroadcastManager.class);
+    LocalBroadcastManager mockLocalBroadcastManager =
+        PowerMockito.mock(LocalBroadcastManager.class);
+    PowerMockito.when(LocalBroadcastManager.getInstance(Matchers.isA(Context.class)))
+        .thenReturn(mockLocalBroadcastManager);
   }
 
   @Test
@@ -138,8 +145,6 @@ public final class ProfileTest extends FacebookPowerMockTestCase {
 
   @Test
   public void testGetSetCurrentProfile() {
-    FacebookSdk.setApplicationId("123456789");
-    FacebookSdk.sdkInitialize(RuntimeEnvironment.application);
     Profile profile1 = createDefaultProfile();
     Profile.setCurrentProfile(profile1);
     assertEquals(ProfileManager.getInstance().getCurrentProfile(), profile1);

--- a/facebook/src/test/java/com/facebook/ProfileTrackerTest.java
+++ b/facebook/src/test/java/com/facebook/ProfileTrackerTest.java
@@ -20,23 +20,35 @@
 
 package com.facebook;
 
+import static com.facebook.util.common.TestHelpersKt.mockLocalBroadcastManager;
 import static org.junit.Assert.*;
 import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
+import android.content.Context;
 import android.content.Intent;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.test.core.app.ApplicationProvider;
 import org.junit.Test;
-import org.robolectric.RuntimeEnvironment;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.robolectric.annotation.LooperMode;
 
 @LooperMode(LEGACY)
+@PrepareForTest({LocalBroadcastManager.class, FacebookSdk.class})
 public class ProfileTrackerTest extends FacebookPowerMockTestCase {
+
   @Test
   public void testStartStopTrackingAndBroadcast() {
-    FacebookSdk.setApplicationId("123456789");
-    FacebookSdk.sdkInitialize(RuntimeEnvironment.application);
-    LocalBroadcastManager localBroadcastManager =
-        LocalBroadcastManager.getInstance(RuntimeEnvironment.application);
+    LocalBroadcastManager localBroadcastManager = mockLocalBroadcastManager();
+    PowerMockito.mockStatic(LocalBroadcastManager.class);
+    PowerMockito.when(LocalBroadcastManager.getInstance(Matchers.isA(Context.class)))
+        .thenReturn(localBroadcastManager);
+
+    PowerMockito.mockStatic(FacebookSdk.class);
+    PowerMockito.when(FacebookSdk.isInitialized()).thenReturn(true);
+    PowerMockito.when(FacebookSdk.getApplicationContext())
+        .thenReturn(ApplicationProvider.getApplicationContext());
     TestProfileTracker testProfileTracker = new TestProfileTracker();
     // Starts tracking
     assertTrue(testProfileTracker.isTracking());

--- a/facebook/src/test/kotlin/com/facebook/util/common/TestHelpers.kt
+++ b/facebook/src/test/kotlin/com/facebook/util/common/TestHelpers.kt
@@ -1,5 +1,10 @@
 package com.facebook.util.common
 
+import android.content.BroadcastReceiver
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.facebook.FacebookSdk
+import java.util.*
 import org.junit.Assert
 import org.mockito.Mockito
 
@@ -19,3 +24,32 @@ inline fun <reified T : Exception> assertThrows(runnable: () -> Any?) {
 inline fun <reified T> anyObject(): T = Mockito.any<T>(T::class.java) ?: castNullAsNonnull()
 
 @Suppress("UNCHECKED_CAST") fun <T> castNullAsNonnull(): T = null as T
+
+fun mockLocalBroadcastManager(): LocalBroadcastManager {
+  val localBroadcastManager = Mockito.mock(LocalBroadcastManager::class.java)
+  val registeredReceiver = ArrayList<BroadcastReceiver>()
+  Mockito.doAnswer { invocation ->
+        val receiver = invocation.getArgument<BroadcastReceiver>(0)
+        registeredReceiver.add(receiver)
+        null
+      }
+      .`when`(localBroadcastManager)
+      .registerReceiver(anyObject(), anyObject())
+  Mockito.doAnswer { invocation ->
+        val receiver = invocation.getArgument<BroadcastReceiver>(0)
+        registeredReceiver.remove(receiver)
+        null
+      }
+      .`when`(localBroadcastManager)
+      .unregisterReceiver(anyObject())
+  Mockito.doAnswer { invocation ->
+        val intent = invocation.getArgument<Intent>(0)
+        for (receiver in registeredReceiver) {
+          receiver.onReceive(FacebookSdk.getApplicationContext(), intent)
+        }
+        null
+      }
+      .`when`(localBroadcastManager)
+      .sendBroadcast(anyObject())
+  return localBroadcastManager
+}


### PR DESCRIPTION
Summary: Many tests around trackers depend on `LocalBroadcastManager`. However, this class is provided by Android system and it's not stable in testing. In order to minimize the false test signals, this diff introduces a simple mock for `LocalBroadcastManager`.

Differential Revision: D27210602

