### PR TITLE
add activity result handling via result registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Login methods using `ActivityResultLauncher` to avoid deprecation results when launching login activity (fixes [issue 875](https://github.com/facebook/facebook-android-sdk/issues/875)
+
 ## [11.0.0] - 2021-06-08
 
 ### Added

--- a/constants.gradle
+++ b/constants.gradle
@@ -24,6 +24,8 @@ project.ext {
     androidxCardviewVersion = "1.0.0"
     androidxBrowserVersion = "1.0.0"
     androidxLegacyVersion = "1.0.0"
+    androidxActivityVersion = "1.2.3"
+    androidxFragmentVersion = "1.3.4"
     junitVersion = "4.13"
 
     kotlinVersion = '1.4.10'

--- a/facebook-common/build.gradle
+++ b/facebook-common/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:${project.ext.androidxVersion}"
     implementation "androidx.cardview:cardview:${project.ext.androidxCardviewVersion}"
     implementation "androidx.browser:browser:${project.ext.androidxBrowserVersion}"
+    implementation "androidx.activity:activity-ktx:${project.ext.androidxActivityVersion}"
+    implementation "androidx.fragment:fragment-ktx:${project.ext.androidxFragmentVersion}"
 
     // Third-party Dependencies
     implementation 'com.google.zxing:core:3.3.3'

--- a/facebook-common/src/main/java/com/facebook/login/FacebookLoginContract.java
+++ b/facebook-common/src/main/java/com/facebook/login/FacebookLoginContract.java
@@ -1,0 +1,138 @@
+package com.facebook.login;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.activity.result.contract.ActivityResultContract;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.facebook.FacebookException;
+
+/**
+ * {@link ActivityResultContract} for login operations.
+ */
+public class FacebookLoginContract extends ActivityResultContract<FacebookLoginContract.Request, FacebookLoginContract.Result> {
+
+  @NonNull
+  @Override
+  public Intent createIntent(@NonNull Context context, Request input) {
+    return ((Request.Login) input).createIntent();
+  }
+
+  @Nullable
+  @Override
+  public SynchronousResult<Result> getSynchronousResult(@NonNull Context context, Request input) {
+    if (input instanceof Request.ActivityLaunchingError) {
+      return new SynchronousResult<Result>(new Result.Error(((Request.ActivityLaunchingError) input).getRequest(),
+              LoginManager.ACTIVITY_RESOLVE_ERROR));
+    } else if (input instanceof Request.Login) {
+      Request.Login loginInput = (Request.Login) input;
+      LoginManager loginManager = loginInput.getLoginManager();
+      // Make sure the static handler for login is registered if there isn't an explicit callback
+      loginManager.registerDefaultCallback();
+      loginManager.logStartLogin(context, loginInput.getRequest());
+      // Sanity check to avoid launching if the activity isn't present
+      if (loginManager.resolveIntent(loginInput.createIntent())) {
+        return null;
+      } else {
+        return new SynchronousResult<Result>(new Result.Error(loginInput.getRequest(),
+                LoginManager.ACTIVITY_RESOLVE_ERROR));
+      }
+    }
+    return new SynchronousResult<Result>(new Result.Error(null, "Invalid request"));
+  }
+
+  @Override
+  public Result parseResult(int resultCode, @Nullable Intent intent) {
+    return new Result.Success(resultCode, intent);
+  }
+
+  public abstract static class Request {
+
+    static class Login extends Request {
+      private final LoginManager loginManager;
+      private final LoginClient.Request request;
+
+      public Login(@NonNull LoginManager loginManager, @NonNull LoginClient.Request request) {
+        this.loginManager = loginManager;
+        this.request = request;
+      }
+
+      @NonNull
+      public LoginManager getLoginManager() {
+        return loginManager;
+      }
+
+      @NonNull
+      public LoginClient.Request getRequest() {
+        return request;
+      }
+
+      public Intent createIntent() {
+        return loginManager.getFacebookActivityIntent(request);
+      }
+    }
+
+    static class ActivityLaunchingError extends Request {
+      private final LoginClient.Request request;
+
+      public ActivityLaunchingError(@Nullable LoginClient.Request request) {
+        this.request = request;
+      }
+
+      @Nullable
+      public LoginClient.Request getRequest() {
+        return request;
+      }
+    }
+  }
+
+  public abstract static class Result {
+
+    static class Error extends Result {
+      private final LoginClient.Request request;
+      private final FacebookException exception;
+
+      public Error(@Nullable LoginClient.Request request, @NonNull FacebookException exception) {
+        this.request = request;
+        this.exception = exception;
+      }
+
+      public Error(@Nullable LoginClient.Request request, @NonNull String message) {
+        this(request, new FacebookException(message));
+      }
+
+      @Nullable
+      public LoginClient.Request getRequest() {
+        return request;
+      }
+
+      @NonNull
+      public FacebookException getException() {
+        return exception;
+      }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+    static class Success extends Result {
+      private final int resultCode;
+      private final Intent intent;
+
+      public Success(int resultCode, @Nullable Intent intent) {
+        this.resultCode = resultCode;
+        this.intent = intent;
+      }
+
+      public int getResultCode() {
+        return resultCode;
+      }
+
+      @Nullable
+      public Intent getIntent() {
+        return intent;
+      }
+    }
+  }
+}

--- a/facebook-login/src/main/res/values/attrs.xml
+++ b/facebook-login/src/main/res/values/attrs.xml
@@ -30,6 +30,7 @@
             <enum name="display_always" value="1" />
             <enum name="never_display" value="2" />
         </attr>
+        <attr name="com_facebook_use_result_contract" format="boolean"/>
     </declare-styleable>
     <declare-styleable name="com_facebook_profile_picture_view">
         <attr name="com_facebook_preset_size">

--- a/samples/FBLoginSample/build.gradle
+++ b/samples/FBLoginSample/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation 'com.facebook.fresco:fresco:2.1.0'
     implementation "androidx.appcompat:appcompat:${project.ext.androidxVersion}"
     implementation "androidx.annotation:annotation:${project.ext.androidxVersion}"
+    implementation "androidx.activity:activity:${project.ext.androidxActivityVersion}"
 
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'androidx.annotation', module: 'annotation'

--- a/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/FacebookLoginActivity.java
+++ b/samples/FBLoginSample/src/main/java/com/facebook/fbloginsample/FacebookLoginActivity.java
@@ -20,9 +20,10 @@
 
 package com.facebook.fbloginsample;
 
-import android.app.Activity;
-import android.content.Intent;
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -30,26 +31,19 @@ import com.facebook.login.LoginResult;
 import com.facebook.login.widget.LoginButton;
 import java.util.Arrays;
 
-public class FacebookLoginActivity extends Activity {
+public class FacebookLoginActivity extends AppCompatActivity {
   private static final String EMAIL = "email";
   private static final String USER_POSTS = "user_posts";
   private static final String AUTH_TYPE = "rerequest";
-
-  private CallbackManager mCallbackManager;
-
-  @Override
-  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    super.onActivityResult(requestCode, resultCode, data);
-    mCallbackManager.onActivityResult(requestCode, resultCode, data);
-  }
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_facebook_login);
-    mCallbackManager = CallbackManager.Factory.create();
+    CallbackManager callbackManager = CallbackManager.Factory.create();
 
     LoginButton mLoginButton = findViewById(R.id.login_button);
+    mLoginButton.setUseResultContract(true);
 
     // Set the initial permissions to request from the user while logging in
     mLoginButton.setPermissions(Arrays.asList(EMAIL, USER_POSTS));
@@ -58,7 +52,7 @@ public class FacebookLoginActivity extends Activity {
 
     // Register a callback to respond to the user
     mLoginButton.registerCallback(
-        mCallbackManager,
+        callbackManager,
         new FacebookCallback<LoginResult>() {
           @Override
           public void onSuccess(LoginResult loginResult) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)

## Pull Request Details

This fixes #875 by adding an alternative using `ActivityResultLauncher` for the methods in `LoginManager`