### PR TITLE
fix(app-events, setUserID): allow null for userID to clear

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/AppEventsLogger.kt
+++ b/facebook-core/src/main/java/com/facebook/appevents/AppEventsLogger.kt
@@ -492,10 +492,10 @@ private constructor(context: Context, applicationId: String?, accessToken: Acces
      *
      * The user ID will be persisted between application instances.
      *
-     * @param userID A User ID
+     * @param userID A User ID, or null to clear the User ID
      */
     @JvmStatic
-    fun setUserID(userID: String) {
+    fun setUserID(userID: String?) {
       AnalyticsUserIDStore.setUserID(userID)
     }
 


### PR DESCRIPTION

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

allows API to function same as facebook-ios-sdk where sending null
to clearUserID clears it

Fixes #1047 

## Test Plan

Test Plan: code that calls setUserID(null) should compile and work
