### PR TITLE
Expose Tournament fields to Java

### DIFF
--- a/facebook-gamingservices/src/main/java/com/facebook/gamingservices/Tournament.kt
+++ b/facebook-gamingservices/src/main/java/com/facebook/gamingservices/Tournament.kt
@@ -31,10 +31,10 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 class Tournament : ShareModel {
-  @SerializedName("id") val identifier: String
-  @SerializedName("tournament_title") val title: String?
-  @SerializedName("tournament_payload") val payload: String?
-  @SerializedName("tournament_end_time") internal var endTime: String? = null
+  @JvmField @SerializedName("id") val identifier: String
+  @JvmField @SerializedName("tournament_title") val title: String?
+  @JvmField @SerializedName("tournament_payload") val payload: String?
+  @JvmField @SerializedName("tournament_end_time") internal var endTime: String? = null
 
   var expiration: ZonedDateTime?
     get() {

--- a/facebook-gamingservices/src/main/java/com/facebook/gamingservices/TournamentUpdater.kt
+++ b/facebook-gamingservices/src/main/java/com/facebook/gamingservices/TournamentUpdater.kt
@@ -22,6 +22,16 @@ class TournamentUpdater {
    * API call succeed.
    */
   fun update(tournament: Tournament, score: Number): TaskCompletionSource<Boolean>? {
+    return update(tournament.identifier, score)
+  }
+
+  /**
+   * Attempts to update a tournament with the provided identifier and score
+   *
+   * @return The task completion source that contains a boolean value on whether or not the Graph
+   * API call succeed.
+   */
+  fun update(identifier: String, score: Number): TaskCompletionSource<Boolean>? {
     val currentAccessToken: AccessToken? = getCurrentAccessToken()
     if (currentAccessToken == null || currentAccessToken.isExpired) {
       throw FacebookException("Attempted to fetch tournament with an invalid access token")
@@ -34,7 +44,7 @@ class TournamentUpdater {
     }
 
     val task: TaskCompletionSource<Boolean> = TaskCompletionSource<Boolean>()
-    val graphPath = "${tournament.identifier}/update_score"
+    val graphPath = "${identifier}/update_score"
     val params = Bundle()
     params.putInt("score", score.toInt())
     val request =


### PR DESCRIPTION
Summary: Exposes Tournament fields to java and adds a method for updating tournaments with just an ID.

Reviewed By: Alaeldin513

Differential Revision:
D36936005 (https://github.com/facebook/facebook-android-sdk/commit/df1cada62cb9dfdb84bc6bbeb06f84bb41c0fc6e)

------------------------------------------------------------------------ (from 01150b9208c6af37a423bbf244f0cabba7607ae6)

fbshipit-source-id: 9cca902e7a99e4b61cf4f17c3818dc33b75a08ff

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
