### PR TITLE
Fix recreating FacebookActivity with LoginFragment

### DIFF
--- a/facebook-common/src/main/java/com/facebook/FacebookActivity.kt
+++ b/facebook-common/src/main/java/com/facebook/FacebookActivity.kt
@@ -43,7 +43,6 @@ open class FacebookActivity : FragmentActivity() {
     private set
 
   public override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
     val intent = intent
 
     // Some apps using this sdk don't put the sdk initialize code in the application
@@ -57,6 +56,7 @@ open class FacebookActivity : FragmentActivity() {
               "your Application's onCreate method.")
       sdkInitialize(applicationContext)
     }
+    super.onCreate(savedInstanceState)
     setContentView(R.layout.com_facebook_activity_layout)
     if (PASS_THROUGH_CANCEL_ACTION == intent.action) {
       handlePassThroughError()


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fix for this issue https://github.com/facebook/facebook-android-sdk/issues/1151
When we try to recreate FacebookActivity with LoginFragment, we need to reinitialize SDK first, then we can start recreating fragments.

## Test Plan

Test Plan: **Add your test plan here**
