### PR TITLE
Set java version in verifybuild.yml

### DIFF
--- a/.github/workflows/verifybuild.yml
+++ b/.github/workflows/verifybuild.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '11'
       - name: Run corekit tests
         run:  GITHUB_ACTIONS=1 ./gradlew :facebook-core:test -i
       - name: Run GamingServicesKit tests


### PR DESCRIPTION
We are using the latest version of Ubuntu to run our github actions. The default java version is now becoming 17 in the newest version of ubuntu, yet our sdk runs using java 11. Therefore, we should explicitly set the java version.

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [ ] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
