### PR TITLE
Bring the call to referrerClient.installReferrer into a thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [18.0.3]
 ### Changed
 - Modified how we pass the content id of purchases in custom events
+- Moved referrerClient.installReferrer to its own thread to avoid blocking the main thread with slow binder calls [Issue: com.android.installreferrer is called in the main thread which leads to ANR](https://github.com/facebook/facebook-android-sdk/issues/1039)
 ### Added
 - Added permissions ACCESS_ADSERVICES_TOPICS to access Google Privacy Sandbox AdServices API. If you need to disable any of the permissions, please include the tools:node="remove" node marker for the particular permissions.
 


### PR DESCRIPTION
Hello Facebook!

To help us review the request, please complete the following:

- ✅  sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- ❓  I've ensured that all existing tests pass and added tests (when/where necessary)
- ✅  I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- ✅  I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

We have an issue with high ANR rates on our Unity app, and the stack trace points to these two long standing open issues with this SDK:

- [com.android.installreferrer is called in the main thread which leads to ANR #1039](https://github.com/facebook/facebook-android-sdk/issues/1039)
- [InstallReferrerUtil.kt com.facebook.internal.InstallReferrerUtil$tryConnectReferrerInfo #672](https://github.com/facebook/facebook-sdk-for-unity/issues/672)

I am not a Kotlin expert, but it seemed like this was a simple change to bring the call to `referrerClient.installReferrer` over to a different thread.

> [!WARNING]
> This change assumes it is okay to make the callback from a different thread than `tryConnectReferrerInfo`.  In my brief check of the codebase, this looked okay, but if necessary we may want to bring the callback back to the main thread.

While doing this, I noticed that the try/catch for cleaning up the `referrerClient` wouldn't work if an exception was thrown from `referrerClient.installReferrer`, so I moved that cleanup to a finally block instead.

## Test Plan

I have run the test app, but cannot test this code quite yet in my own app, as I haven't explored how to bring this over to Unity.  I was hoping by starting here with this repository I could get feedback before trying to get this brought in to the Unity package as well.

If there is something I can do to help test this, please let me know!  My goal here is to get the ball rolling with this conversation so that we can address the high ANR rates caused by this SDK.