### PR TITLE
Fix NoClassDefFoundError for OutcomeReceiver on API < 31

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/gps/ara/GpsAraTriggersManager.kt
+++ b/facebook-core/src/main/java/com/facebook/appevents/gps/ara/GpsAraTriggersManager.kt
@@ -11,6 +11,7 @@ package com.facebook.appevents.gps.ara
 import android.adservices.measurement.MeasurementManager
 import android.annotation.TargetApi
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.OutcomeReceiver
 import android.util.Log
@@ -47,6 +48,8 @@ object GpsAraTriggersManager {
 
     @TargetApi(34)
     fun registerTrigger(applicationId: String, event: AppEvent) {
+        // OutcomeReceiver was added in API 31.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
         if (applicationId == null || !isValidEvent(event)) return
         if (!canRegisterTrigger()) return
 

--- a/facebook-core/src/main/java/com/facebook/appevents/gps/pa/PACustomAudienceClient.kt
+++ b/facebook-core/src/main/java/com/facebook/appevents/gps/pa/PACustomAudienceClient.kt
@@ -17,6 +17,7 @@ import android.adservices.customaudience.CustomAudienceManager
 import android.adservices.customaudience.JoinCustomAudienceRequest
 import android.adservices.customaudience.TrustedBiddingData
 import android.annotation.TargetApi
+import android.os.Build
 import android.os.Bundle
 import android.os.OutcomeReceiver
 import android.util.Log
@@ -104,6 +105,10 @@ object PACustomAudienceClient {
 
     @TargetApi(34)
     private fun joinCustomAudienceImpl(appId: String?, eventName: String?) {
+        // OutcomeReceiver was added in API 31.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return
+        }
         val caName = validateAndCreateCAName(appId, eventName)
         if (caName == null) {
             return

--- a/facebook-core/src/main/java/com/facebook/appevents/gps/topics/GpsTopicsManager.kt
+++ b/facebook-core/src/main/java/com/facebook/appevents/gps/topics/GpsTopicsManager.kt
@@ -12,6 +12,7 @@ import android.adservices.topics.GetTopicsRequest
 import android.adservices.topics.GetTopicsResponse
 import android.adservices.topics.TopicsManager
 import android.annotation.TargetApi
+import android.os.Build
 import android.os.OutcomeReceiver
 import android.util.Log
 import com.facebook.FacebookSdk
@@ -81,6 +82,10 @@ object GpsTopicsManager {
 
     @JvmStatic
     fun shouldObserveTopics(): Boolean {
+        // OutcomeReceiver was added in API 31.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return false
+        }
         if (!isTopicsObservationEnabled.get()) {
             return false
         }

--- a/facebook-core/src/test/kotlin/com/facebook/appevents/gps/ara/GpsAraTriggersManagerTest.kt
+++ b/facebook-core/src/test/kotlin/com/facebook/appevents/gps/ara/GpsAraTriggersManagerTest.kt
@@ -37,7 +37,7 @@ import java.util.concurrent.Executor
     MeasurementManager::class,
     GpsAraTriggersManager::class
 )
-@Config(sdk = [23])
+@Config(sdk = [31])
 class GpsAraTriggersManagerTest : FacebookPowerMockTestCase() {
     private val applicationId = "app_id"
     private val contentId = "product_id_123"
@@ -85,6 +85,14 @@ class GpsAraTriggersManagerTest : FacebookPowerMockTestCase() {
         whenever(FacebookSdk.isInitialized()).thenReturn(true)
 
         GpsAraTriggersManager.enable()
+    }
+
+    @Test
+    @Config(sdk = [23])
+    fun testRegisterTriggerReturnsEarlyOnApiBelow31() {
+        val event = createEvent(AppEventsConstants.EVENT_NAME_VIEWED_CONTENT)
+        GpsAraTriggersManager.registerTrigger(applicationId, event)
+        assertEquals(0, registerTriggerCalledTimes)
     }
 
     @Test

--- a/facebook-core/src/test/kotlin/com/facebook/appevents/gps/pa/PACustomAudienceClientTest.kt
+++ b/facebook-core/src/test/kotlin/com/facebook/appevents/gps/pa/PACustomAudienceClientTest.kt
@@ -34,6 +34,7 @@ import org.powermock.api.mockito.PowerMockito.mock
 import org.powermock.api.mockito.PowerMockito.mockStatic
 import org.powermock.api.mockito.PowerMockito.whenNew
 import org.powermock.core.classloader.annotations.PrepareForTest
+import org.robolectric.annotation.Config
 import java.util.concurrent.Executor
 
 @PrepareForTest(
@@ -45,6 +46,7 @@ import java.util.concurrent.Executor
     AdSelectionSignals::class,
     PACustomAudienceClient::class
 )
+@Config(sdk = [31])
 class PACustomAudienceClientTest : FacebookPowerMockTestCase() {
     private var customAudienceManager: CustomAudienceManager? = null
     private lateinit var mockLogger: GpsDebugLogger
@@ -107,6 +109,22 @@ class PACustomAudienceClientTest : FacebookPowerMockTestCase() {
         whenNew(GpsDebugLogger::class.java)
             .withAnyArguments()
             .thenReturn(mockLogger)
+    }
+
+    @Test
+    @Config(sdk = [23])
+    fun testJoinCustomAudienceReturnsEarlyOnApiBelow31() {
+        mockStatic(CustomAudienceManager::class.java)
+        whenever(CustomAudienceManager.get(any<Context>())).thenReturn(customAudienceManager)
+
+        PACustomAudienceClient.enable()
+        PACustomAudienceClient.joinCustomAudience("1234", createEvent("test_event"))
+
+        verify(customAudienceManager, times(0))?.joinCustomAudience(
+            any<JoinCustomAudienceRequest>(),
+            any<Executor>(),
+            any<OutcomeReceiver<Any, Exception>>()
+        )
     }
 
     @Test

--- a/facebook-core/src/test/kotlin/com/facebook/appevents/gps/topics/GpsTopicsManagerTest.kt
+++ b/facebook-core/src/test/kotlin/com/facebook/appevents/gps/topics/GpsTopicsManagerTest.kt
@@ -40,7 +40,7 @@ import com.facebook.internal.FeatureManager
     Topic::class,
     FeatureManager::class,
 )
-@Config(sdk = [23])
+@Config(sdk = [31])
 class GpsTopicsManagerTest : FacebookPowerMockTestCase() {
     private lateinit var mockTopicsManager: TopicsManager
 


### PR DESCRIPTION
This PR attempts to fix https://github.com/facebook/facebook-android-sdk/issues/1357

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla/individual/?success=1&form[username]=wyqlxf&form[name]=wangyongqi&form[email]=1033886748%40qq.com&form[email2]=&form[country]=CN&form[agree]=1)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Add `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S` check before using ad services APIs. On API < 31, the SDK returns early without calling these APIs, preventing the crash.

## Test Plan

Test Plan:  Run `./gradlew :facebook-core:testDebugUnitTest --tests "com.facebook.appevents.gps.*"` - all tests pass.
