### PR TITLE
Fix NonceUtil.isValidNonce to reject all whitespace, not just spaces

### DIFF
--- a/facebook-common/src/main/java/com/facebook/login/NonceUtil.kt
+++ b/facebook-common/src/main/java/com/facebook/login/NonceUtil.kt
@@ -15,7 +15,7 @@ object NonceUtil {
       return false
     }
 
-    val hasWhiteSpace = nonce.indexOf(' ') >= 0
+    val hasWhiteSpace = nonce.any { it.isWhitespace() }
     return !hasWhiteSpace
   }
 }

--- a/facebook-common/src/test/kotlin/com/facebook/login/NonceUtilTest.kt
+++ b/facebook-common/src/test/kotlin/com/facebook/login/NonceUtilTest.kt
@@ -25,6 +25,13 @@ class NonceUtilTest : FacebookPowerMockTestCase() {
   }
 
   @Test
+  fun `test nonce with non-space whitespace is invalid`() {
+    assertThat(NonceUtil.isValidNonce("nonce\t")).isFalse
+    assertThat(NonceUtil.isValidNonce("nonce\n")).isFalse
+    assertThat(NonceUtil.isValidNonce("non\rce")).isFalse
+  }
+
+  @Test
   fun `test empty nonce`() {
     assertThat(NonceUtil.isValidNonce("")).isFalse
   }


### PR DESCRIPTION
## Summary

`NonceUtil.isValidNonce` is meant to reject any nonce that contains whitespace, but the check only matched the literal space character:

```kotlin
val hasWhiteSpace = nonce.indexOf(' ') >= 0
return !hasWhiteSpace
```

Despite the local being named `hasWhiteSpace`, a nonce containing a tab (`\t`), newline (`\n`), or carriage return (`\r`) passed validation. That nonce is later fed into the OIDC login flow through `LoginConfiguration`'s `require(NonceUtil.isValidNonce(nonce) && ...)`, where embedded whitespace can break request handling downstream.

## Change

Use `Char.isWhitespace()` so every whitespace character is rejected:

```kotlin
val hasWhiteSpace = nonce.any { it.isWhitespace() }
return !hasWhiteSpace
```

## Tests

Added regression coverage in `NonceUtilTest` for tab, newline, and carriage return — each of which previously passed validation and now correctly fails. Existing valid/space/empty cases are unchanged.

> Note: the SDK's test suite requires the Android SDK/Gradle toolchain, which wasn't available in my local environment, so the new tests were validated by inspection. CI should exercise them.
Co-authored-by:[Baradhan-Madhu](https://github.com/Baradhan-Madhu)
