### PR TITLE
Fix MD5 checksum encoding dropping leading zeros in HashUtils

### DIFF
--- a/facebook-core/src/main/java/com/facebook/appevents/internal/HashUtils.kt
+++ b/facebook-core/src/main/java/com/facebook/appevents/internal/HashUtils.kt
@@ -20,7 +20,6 @@ import java.lang.reflect.Field
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
-import java.math.BigInteger
 import java.security.MessageDigest
 import java.security.cert.CertificateFactory
 import java.util.concurrent.locks.ReentrantLock
@@ -54,7 +53,7 @@ internal object HashUtils {
       } while (numRead != -1)
 
       // Convert byte array to hex string and return result.
-      return BigInteger(1, md.digest()).toString(16)
+      return AppEventUtility.bytesToHex(md.digest())
     }
   }
 
@@ -97,7 +96,7 @@ internal object HashUtils {
                               getTypeMethod.invoke(c) == TYPE_WHOLE_MD5) {
                             val getValueMethod: Method = c.javaClass.getMethod("getValue")
                             val checksumValue = getValueMethod.invoke(c) as ByteArray
-                            resultChecksum = BigInteger(1, checksumValue).toString(16)
+                            resultChecksum = AppEventUtility.bytesToHex(checksumValue)
                             lock.lock()
                             try {
                               checksumReady.signalAll()

--- a/facebook-core/src/test/kotlin/com/facebook/appevents/internal/HashUtilsTest.kt
+++ b/facebook-core/src/test/kotlin/com/facebook/appevents/internal/HashUtilsTest.kt
@@ -29,6 +29,22 @@ class HashUtilsTest : FacebookPowerMockTestCase() {
   }
 
   @Test
+  fun `test computeChecksum preserves leading zeros in digest`() {
+    // MD5("a") = 0cc175b9c0f1b6a831c399e269772661 (one leading zero nibble) and
+    // MD5("jk8ssl") = 0000000018e6137ac2caab16074784a6 (eight leading zero nibbles).
+    // A digest with leading zeros must still render as a full 32-character hex string.
+    val singleZero = File.createTempFile("tempFile.txt", null)
+    singleZero.writeText("a")
+    singleZero.deleteOnExit()
+    assertEquals("0cc175b9c0f1b6a831c399e269772661", HashUtils.computeChecksum(singleZero.path))
+
+    val manyZeros = File.createTempFile("tempFile.txt", null)
+    manyZeros.writeText("jk8ssl")
+    manyZeros.deleteOnExit()
+    assertEquals("0000000018e6137ac2caab16074784a6", HashUtils.computeChecksum(manyZeros.path))
+  }
+
+  @Test
   fun `test computeChecksum with empty file`() {
     val tempFile = File.createTempFile("tempFile.txt", null)
     tempFile.deleteOnExit()


### PR DESCRIPTION
## Summary

`HashUtils` hex-encodes MD5 digests with:

```kotlin
BigInteger(1, md.digest()).toString(16)
```

`BigInteger.toString(16)` treats the digest as a number, so it **drops leading zeros**. Any digest that begins with one or more zero nibbles produces a hex string shorter than the expected 32 characters:

| Input | Correct MD5 | What `BigInteger` produced |
|-------|-------------|----------------------------|
| `"a"` | `0cc175b9c0f1b6a831c399e269772661` | `cc175b9c0f1b6a831c399e269772661` (31 chars) |
| `"jk8ssl"` | `0000000018e6137ac2caab16074784a6` | `18e6137ac2caab16074784a6` (24 chars) |

Roughly one digest in sixteen starts with a zero nibble, so a meaningful fraction of checksums silently did not equal the canonical MD5 value. The same flaw was present in both `computeFileMd5` and the `PackageManager.requestChecksums` path.

## Change

Use `AppEventUtility.bytesToHex` — already defined in the same package — which formats each byte as exactly two hex digits (`%02x`) and therefore preserves leading zeros. This also removes the now-unused `BigInteger` import.

## Tests

Added a regression test in `HashUtilsTest` covering a single leading-zero nibble (`"a"`) and many leading-zero nibbles (`"jk8ssl"`), both of which failed before this change. Existing non-zero-prefixed cases are unchanged.

> Note: the SDK test suite needs the Android/Gradle toolchain, which wasn't available in my environment, so the new assertions were verified against the canonical `md5` values by inspection. CI should exercise them.
